### PR TITLE
Declare documented types master

### DIFF
--- a/lib/common_test/doc/src/ct_snmp.xml
+++ b/lib/common_test/doc/src/ct_snmp.xml
@@ -164,8 +164,8 @@
       done by defining a configuration data variable on the following form:</p>
 
     <pre>
- {snmp_app, [{manager, [snmp_app_manager_params()]},
-             {agent, [snmp_app_agent_params()]}]}.</pre>
+ {snmp_app, [{manager, [SNMPAppManagerParams :: term()]},
+             {agent, [SNMPAppAgentParams :: term()]}]}.</pre>
 
     <p>A name for the data must be allocated in the suite using
       <c>require</c> (see the example above). Pass this name as argument

--- a/lib/common_test/src/ct.erl
+++ b/lib/common_test/src/ct.erl
@@ -41,15 +41,6 @@
 %%%   <c>init_per_testcase/2</c> in the test suite.</li>
 %%% </ul>
 
-%%% @type var_name() = atom(). A variable name which is specified when
-%%% <c>ct:require/2</c> is called,
-%%% e.g. <c>ct:require(mynodename,{node,[telnet]})</c>
-%%%
-%%% @type target_name() = var_name(). The name of a target.
-%%%
-%%% @type handle() = ct_gen_conn:handle() | term(). The identity of a
-%%% specific connection.
-
 -module(ct).
 
 -include("ct.hrl").
@@ -87,6 +78,19 @@
 
 -export([get_target_name/1]).
 -export([parse_table/1, listenv/1]).
+
+
+-type var_name() :: atom().
+%% A variable name which is specified when <c>ct:require/2</c> is called,
+%% e.g. <c>ct:require(mynodename,{node,[telnet]})</c>
+
+-type target_name() :: var_name().
+%% The name of a target.
+
+-type handle() :: ct_gen_conn:handle() | term().
+%% The identity of a specific connection.
+
+-export_type([target_name/0]).
 
 %%%-----------------------------------------------------------------
 %%% @spec install(Opts) -> ok | {error,Reason}
@@ -880,14 +884,15 @@ make_priv_dir() ->
     test_server:make_priv_dir().
 
 %%%-----------------------------------------------------------------
-%%% @spec get_target_name(Handle) -> {ok,TargetName} | {error,Reason}
-%%%      Handle = handle()
-%%%      TargetName = target_name()
 %%% @doc Return the name of the target that the given connection
 %%% belongs to.
+-spec get_target_name(Handle) -> {ok,TargetName} | {error,Reason} when
+      Handle :: handle(),
+      TargetName :: target_name(),
+      Reason :: term().
 get_target_name(Handle) ->
     ct_util:get_target_name(Handle).
-    
+
 %%%-----------------------------------------------------------------
 %%% @spec parse_table(Data) -> {Heading,Table}
 %%%       Data = [string()]

--- a/lib/common_test/src/ct_ftp.erl
+++ b/lib/common_test/src/ct_ftp.erl
@@ -43,13 +43,6 @@
 %%% API
 
 %%%-----------------------------------------------------------------
-%%% @spec put(KeyOrName,LocalFile,RemoteFile) -> ok | {error,Reason}
-%%%      KeyOrName = Key | Name
-%%%      Key = atom()
-%%%      Name = ct:target_name()
-%%%      LocalFile = string()
-%%%      RemoteFile = string()
-%%%
 %%% @doc Open a ftp connection and send a file to the remote host.
 %%%
 %%% <p><code>LocalFile</code> and <code>RemoteFile</code> must be
@@ -68,18 +61,18 @@
 %%%        {username,Username},
 %%%        {password,Password}]}.</pre>
 %%% @see ct:require/2
+-spec put(KeyOrName, LocalFile, RemoteFile) -> ok | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      LocalFile :: file:name(),
+      RemoteFile :: file:name(),
+      Reason :: term().
 put(KeyOrName,LocalFile,RemoteFile) ->
     Fun = fun(Ftp) -> send(Ftp,LocalFile,RemoteFile) end,
     open_and_do(KeyOrName,Fun).
 
 %%%-----------------------------------------------------------------
-%%% @spec get(KeyOrName,RemoteFile,LocalFile) -> ok | {error,Reason}
-%%%      KeyOrName = Key | Name
-%%%      Key = atom()
-%%%      Name = ct:target_name()
-%%%      RemoteFile = string()
-%%%      LocalFile = string()
-%%%
 %%% @doc Open a ftp connection and fetch a file from the remote host.
 %%%
 %%% <p><code>RemoteFile</code> and <code>LocalFile</code> must be
@@ -88,18 +81,19 @@ put(KeyOrName,LocalFile,RemoteFile) ->
 %%% <p>The config file must be as for put/3.</p>
 %%% @see put/3
 %%% @see ct:require/2
+-spec get(KeyOrName,RemoteFile,LocalFile) -> ok | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      RemoteFile :: file:name(),
+      LocalFile :: file:name(),
+      Reason :: term().
 get(KeyOrName,RemoteFile,LocalFile) ->
     Fun = fun(Ftp) -> recv(Ftp,RemoteFile,LocalFile) end,
     open_and_do(KeyOrName,Fun).
 
 
 %%%-----------------------------------------------------------------
-%%% @spec open(KeyOrName) -> {ok,Handle} | {error,Reason}
-%%%      KeyOrName = Key | Name
-%%%      Key = atom()
-%%%      Name = ct:target_name()
-%%%      Handle = handle()
-%%% 
 %%% @doc Open an FTP connection to the specified node.
 %%% <p>You can open one connection for a particular <code>Name</code> and
 %%% use the same name as reference for all subsequent operations. If you
@@ -112,6 +106,12 @@ get(KeyOrName,RemoteFile,LocalFile) ->
 %%% <p>See <c>ct:require/2</c> for how to create a new <c>Name</c></p>
 %%%
 %%% @see ct:require/2
+-spec open(KeyOrName) -> {ok,Handle} | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      Handle :: handle(),
+      Reason :: term().
 open(KeyOrName) ->
     case ct_util:get_key_from_name(KeyOrName) of
 	{ok,node} ->
@@ -154,11 +154,13 @@ open(KeyOrName,Username,Password) ->
 
 
 %%%-----------------------------------------------------------------
-%%% @spec send(Connection,LocalFile) -> ok | {error,Reason}
-%%%
 %%% @doc Send a file over FTP.
 %%% <p>The file will get the same name on the remote host.</p>
 %%% @see send/3
+-spec send(Connection, LocalFile) -> ok | {error,Reason} when
+      Connection :: connection(),
+      LocalFile :: file:name(),
+      Reason :: term().
 send(Connection,LocalFile) ->
     send(Connection,LocalFile,filename:basename(LocalFile)).
 
@@ -169,8 +171,8 @@ send(Connection,LocalFile) ->
 %%% @end
 -spec send(Connection, LocalFile, RemoteFile) -> ok | {error,Reason} when
       Connection :: connection(),
-      LocalFile :: string(),
-      RemoteFile :: string(),
+      LocalFile :: file:name(),
+      RemoteFile :: file:name(),
       Reason :: term().
 send(Connection,LocalFile,RemoteFile) ->
     case get_handle(Connection) of
@@ -181,11 +183,13 @@ send(Connection,LocalFile,RemoteFile) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec recv(Connection,RemoteFile) -> ok | {error,Reason}
-%%%
 %%% @doc Fetch a file over FTP.
 %%% <p>The file will get the same name on the local host.</p>
 %%% @see recv/3
+-spec recv(Connection, RemoteFile) -> ok | {error,Reason} when
+      Connection :: connection(),
+      RemoteFile :: file:name(),
+      Reason :: term().
 recv(Connection,RemoteFile) ->
     recv(Connection,RemoteFile,filename:basename(RemoteFile)).
 
@@ -196,8 +200,8 @@ recv(Connection,RemoteFile) ->
 %%% @end
 -spec recv(Connection, RemoteFile, LocalFile) -> ok | {error,Reason} when
       Connection :: connection(),
-      RemoteFile :: string(),
-      LocalFile :: string(),
+      RemoteFile :: file:name(),
+      LocalFile :: file:name(),
       Reason :: term().
 recv(Connection,RemoteFile,LocalFile) ->
     case get_handle(Connection) of
@@ -211,7 +215,7 @@ recv(Connection,RemoteFile,LocalFile) ->
 %%% @doc Change directory on remote host.
 -spec cd(Connection, Dir) -> ok | {error,Reason} when
       Connection :: connection(),
-      Dir :: string(),
+      Dir :: file:name(),
       Reason :: term().
 cd(Connection,Dir) ->
     case get_handle(Connection) of
@@ -225,8 +229,8 @@ cd(Connection,Dir) ->
 %%% @doc List the directory Dir.
 -spec ls(Connection, Dir) -> {ok,Listing} | {error,Reason} when
       Connection :: connection(),
-      Dir :: string(),
-      Listing :: string(),
+      Dir :: file:name(),
+      Listing :: file:name(),
       Reason :: term().
 ls(Connection,Dir) ->
     case get_handle(Connection) of
@@ -249,12 +253,12 @@ type(Connection,Type) ->
 	Error ->
 	    Error
     end.
-    
+
 %%%-----------------------------------------------------------------
 %%% @doc Delete a file on remote host
 -spec delete(Connection, File) -> ok | {error,Reason} when
       Connection :: connection(),
-      File :: string(),
+      File :: file:name(),
       Reason :: term().
 delete(Connection,File) ->
     case get_handle(Connection) of

--- a/lib/common_test/src/ct_ftp.erl
+++ b/lib/common_test/src/ct_ftp.erl
@@ -19,10 +19,6 @@
 %%
 
 %%% @doc FTP client module (based on the FTP support of the INETS application).
-%%%
-%%% @type connection() = handle() | ct:target_name()
-%%% @type handle() = ct_gen_conn:handle(). Handle for a specific
-%%% ftp connection.
 
 -module(ct_ftp).
 
@@ -34,6 +30,10 @@
 -export([init/3,handle_msg/2,reconnect/2,terminate/2]).
 
 -include("ct_util.hrl").
+
+-type connection() :: handle() | ct:target_name().
+-type handle() :: ct_gen_conn:handle().
+%% Handle for a specific ftp connection.
 
 -record(state,{ftp_pid,target_name}).
 
@@ -163,14 +163,15 @@ send(Connection,LocalFile) ->
     send(Connection,LocalFile,filename:basename(LocalFile)).
 
 %%%-----------------------------------------------------------------
-%%% @spec send(Connection,LocalFile,RemoteFile) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%      LocalFile = string()
-%%%      RemoteFile = string()
-%%%
 %%% @doc Send a file over FTP.
 %%%
 %%% <p>The file will be named <code>RemoteFile</code> on the remote host.</p>
+%%% @end
+-spec send(Connection, LocalFile, RemoteFile) -> ok | {error,Reason} when
+      Connection :: connection(),
+      LocalFile :: string(),
+      RemoteFile :: string(),
+      Reason :: term().
 send(Connection,LocalFile,RemoteFile) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -189,14 +190,15 @@ recv(Connection,RemoteFile) ->
     recv(Connection,RemoteFile,filename:basename(RemoteFile)).
 
 %%%-----------------------------------------------------------------
-%%% @spec recv(Connection,RemoteFile,LocalFile) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%      RemoteFile = string()
-%%%      LocalFile = string()
-%%%
 %%% @doc Fetch a file over FTP.
 %%%
 %%% <p>The file will be named <code>LocalFile</code> on the local host.</p>
+%%% @end
+-spec recv(Connection, RemoteFile, LocalFile) -> ok | {error,Reason} when
+      Connection :: connection(),
+      RemoteFile :: string(),
+      LocalFile :: string(),
+      Reason :: term().
 recv(Connection,RemoteFile,LocalFile) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -206,11 +208,11 @@ recv(Connection,RemoteFile,LocalFile) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec cd(Connection,Dir) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%      Dir = string()
-%%%
 %%% @doc Change directory on remote host.
+-spec cd(Connection, Dir) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Dir :: string(),
+      Reason :: term().
 cd(Connection,Dir) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -220,12 +222,12 @@ cd(Connection,Dir) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec ls(Connection,Dir) -> {ok,Listing} | {error,Reason}
-%%%      Connection = connection()
-%%%      Dir = string()
-%%%      Listing = string()
-%%%
 %%% @doc List the directory Dir.
+-spec ls(Connection, Dir) -> {ok,Listing} | {error,Reason} when
+      Connection :: connection(),
+      Dir :: string(),
+      Listing :: string(),
+      Reason :: term().
 ls(Connection,Dir) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -235,11 +237,11 @@ ls(Connection,Dir) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec type(Connection,Type) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%      Type = ascii | binary
-%%%
 %%% @doc Change file transfer type
+-spec type(Connection, Type) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Type :: ascii | binary,
+      Reason :: term().
 type(Connection,Type) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -249,11 +251,11 @@ type(Connection,Type) ->
     end.
     
 %%%-----------------------------------------------------------------
-%%% @spec delete(Connection,File) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%      File = string()
-%%%
 %%% @doc Delete a file on remote host
+-spec delete(Connection, File) -> ok | {error,Reason} when
+      Connection :: connection(),
+      File :: string(),
+      Reason :: term().
 delete(Connection,File) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -263,10 +265,10 @@ delete(Connection,File) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec close(Connection) -> ok | {error,Reason}
-%%%      Connection = connection()
-%%%
 %%% @doc Close the FTP connection.
+-spec close(Connection) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Reason :: term().
 close(Connection) ->
     case get_handle(Connection) of
 	{ok,Pid} ->

--- a/lib/common_test/src/ct_gen_conn.erl
+++ b/lib/common_test/src/ct_gen_conn.erl
@@ -19,9 +19,6 @@
 %%
 
 %%% @doc Generic connection owner process.
-%%%
-%%% @type handle() = pid(). A handle for using a connection implemented
-%%% with ct_gen_conn.erl.
 
 -module(ct_gen_conn).
 
@@ -34,7 +31,8 @@
 %%----------------------------------------------------------------------
 -export_type([server_id/0,
 	      target_name/0,
-	      key_or_name/0]).
+	      key_or_name/0,
+              handle/0]).
 
 -ifdef(debug).
 -define(dbg,true).
@@ -64,6 +62,8 @@
 %% `require' statement or a call to {@link ct:require/2} in the
 %% test suite.
 -type key_or_name() :: server_id() | target_name().
+-opaque handle() :: pid().
+%% A handle for using a connection implemented with ct_gen_conn.erl.
 
 
 %%%-----------------------------------------------------------------

--- a/lib/common_test/src/ct_gen_conn.erl
+++ b/lib/common_test/src/ct_gen_conn.erl
@@ -65,18 +65,24 @@
 -opaque handle() :: pid().
 %% A handle for using a connection implemented with ct_gen_conn.erl.
 
-
+-spec start(Address, InitData, CallbackMod, Options) -> {ok,Handle} | {error,Reason} when
+      Address :: term(),
+      InitData :: term(),
+      CallbackMod :: module(),
+      Options :: [Option],
+      Option :: {name,Name} | {use_existing_connection,boolean()} |
+                {reconnect,boolean()} | {forward_messages,boolean()},
+      Name :: ct:target_name(),
+      Handle :: handle(),
+      Reason :: any();
+           (Name, Address, InitData, CallbackMod) -> {ok,Handle} | {error,Reason} when
+      Name :: ct:target_name(),
+      Address :: term(),
+      InitData :: term(),
+      CallbackMod :: module(),
+      Handle :: handle(),
+      Reason :: any().
 %%%-----------------------------------------------------------------
-%%% @spec start(Address,InitData,CallbackMod,Opts) ->
-%%%                                     {ok,Handle} | {error,Reason}
-%%%      Name = term()
-%%%      CallbackMod = atom()
-%%%      InitData = term()
-%%%      Address = term()
-%%%      Opts = [Opt]
-%%%      Opt = {name,Name} | {use_existing_connection,boolean()} |
-%%%            {reconnect,boolean()} | {forward_messages,boolean()}
-%%%
 %%% @doc Open a connection and start the generic connection owner process.
 %%%
 %%% <p>The <code>CallbackMod</code> is a specific callback module for
@@ -135,58 +141,54 @@ start(Name,Address,InitData,CallbackMod) ->
     do_start(Address,InitData,CallbackMod,[{name,Name},{old,true}]).
 
 %%%-----------------------------------------------------------------
-%%% @spec stop(Handle) -> ok
-%%%      Handle = handle()
-%%%
 %%% @doc Close the connection and stop the process managing it.
+-spec stop(Handle) -> ok when
+      Handle :: handle().
 stop(Handle) ->
     call(Handle,stop,5000).
 
 %%%-----------------------------------------------------------------
-%%% @spec get_conn_pid(Handle) -> ok
-%%%      Handle = handle()
-%%%
 %%% @doc Return the connection pid associated with Handle
+-spec get_conn_pid(Handle) -> ok when
+      Handle :: handle().
 get_conn_pid(Handle) ->
     call(Handle,get_conn_pid).
 
 %%%-----------------------------------------------------------------
-%%% @spec log(Heading,Format,Args) -> ok
-%%%
 %%% @doc Log activities on the current connection (tool-internal use only).
 %%% @see ct_logs:log/3
+-spec log(Heading, Format, Args) -> ok when
+      Heading :: string(),
+      Format :: string(),
+      Args :: list().
 log(Heading,Format,Args) ->
     log(log,[Heading,Format,Args]).
 
 %%%-----------------------------------------------------------------
-%%% @spec start_log(Heading) -> ok
-%%%
 %%% @doc Log activities on the current connection (tool-internal use only).
 %%% @see ct_logs:start_log/1
+-spec start_log(Heading) -> ok when
+      Heading :: string().
 start_log(Heading) ->
     log(start_log,[Heading]).
 
 %%%-----------------------------------------------------------------
-%%% @spec cont_log(Format,Args) -> ok
-%%%
 %%% @doc Log activities on the current connection (tool-internal use only).
 %%% @see ct_logs:cont_log/2
+-spec cont_log(Format, Args) -> ok when
+      Format :: string(),
+      Args :: list().
 cont_log(Format,Args) ->
     log(cont_log,[Format,Args]).
 
 %%%-----------------------------------------------------------------
-%%% @spec end_log() -> ok
-%%%
 %%% @doc Log activities on the current connection (tool-internal use only).
 %%% @see ct_logs:end_log/0
+-spec end_log() -> ok.
 end_log() ->
     log(end_log,[]).
 
 %%%-----------------------------------------------------------------
-%%% @spec do_within_time(Fun,Timeout) -> FunResult | {error,Reason}
-%%%      Fun = function()
-%%%      Timeout = integer()
-%%%
 %%% @doc Execute a function within a limited time (tool-internal use only).
 %%%
 %%% <p>Execute the given <code>Fun</code>, but interrupt if it takes
@@ -194,6 +196,11 @@ end_log() ->
 %%%
 %%% <p>The execution is also interrupted if the connection is
 %%% closed.</p>
+-spec do_within_time(Fun, Timeout) -> FunResult | {error,Reason} when
+      Fun :: fun(() -> FunResult),
+      FunResult :: term(),
+      Timeout :: integer(),
+      Reason :: any().
 do_within_time(Fun,Timeout) ->
     Self = self(),
     Silent = get(silent),
@@ -426,7 +433,7 @@ reconnect(Opts) ->
 
 log(Func,Args) ->
     case get(silent) of
-	true when not ?dbg->
+	true when not ?dbg ->
 	    ok;
 	_ ->
 	    apply(ct_logs,Func,Args)

--- a/lib/common_test/src/ct_snmp.erl
+++ b/lib/common_test/src/ct_snmp.erl
@@ -161,7 +161,12 @@
 -type error_index() :: integer().
 -type varbinds() :: [varbind()].
 -type varbind() :: term().
--type value_type() :: o | i | u | g | s | b | ip | op | c32 | c64 | tt.
+-type value_type() :: o  %% 'OBJECT IDENTIFIER'
+                    | i  %% 'INTEGER'
+                    | u  %% 'Unsigned32'
+                    | g  %% 'Unsigned32'
+                    | s  %% 'OCTET STRING'
+                    | b | ip | op | c32 | c64 | tt.
 -type vars_and_vals() :: [var_and_val()].
 -type value() :: term().
 -type var_and_val() :: {oid(), value_type(), value()} | {oid(), value()}.
@@ -200,8 +205,10 @@
 %%%=========================================================================
 
 %%%-----------------------------------------------------------------
-%%% @spec start(Config, MgrAgentConfName) -> ok
 %%% @equiv start(Config, MgrAgentConfName, undefined)
+-spec start(Config, MgrAgentConfName) -> ok when
+      Config :: [{Key :: atom(), Value :: term()}],
+      MgrAgentConfName :: atom().
 start(Config, MgrAgentConfName) ->
     start(Config, MgrAgentConfName, undefined).
 
@@ -219,7 +226,7 @@ start(Config, MgrAgentConfName) ->
 %%% with (and possibly override) default values set by <code>ct_snmp</code>.
 %%% @end
 -spec start(Config, MgrAgentConfName, SnmpAppConfName) -> ok when
-      Config :: agent_config(),
+      Config :: [{Key :: atom(), Value :: term()}],
       MgrAgentConfName :: atom(),
       SnmpAppConfName :: atom().
 start(Config, MgrAgentConfName, SnmpAppConfName) ->
@@ -243,7 +250,7 @@ start(Config, MgrAgentConfName, SnmpAppConfName) ->
 
 %%% @doc Stops the snmp manager and/or agent removes all files created.
 -spec stop(Config) -> ok when
-      Config :: agent_config().
+      Config :: [{Key :: atom(), Value :: term()}].
 stop(Config) ->
     PrivDir = ?config(priv_dir, Config),
     application:stop(snmp),
@@ -281,7 +288,7 @@ get_next_values(Agent, Oids, MgrAgentConfName) ->
       Agent :: agent_name(),
       VarsAndVals :: vars_and_vals(),
       MgrAgentConfName :: atom(),
-      Config :: agent_config().
+      Config :: [{Key :: atom(), Value :: term()}].
 set_values(Agent, VarsAndVals, MgrAgentConfName, Config) ->
     PrivDir = ?config(priv_dir, Config),
     [Uid | _] = agent_conf(Agent, MgrAgentConfName),
@@ -305,7 +312,7 @@ set_values(Agent, VarsAndVals, MgrAgentConfName, Config) ->
 %%% side-effects.
 %%% @end
 -spec set_info(Config) -> [{Agent, OldVarsAndVals, NewVarsAndVals}] when
-      Config :: agent_config(),
+      Config :: [{Key :: atom(), Value :: term()}],
       Agent :: agent_name(),
       OldVarsAndVals :: vars_and_vals(),
       NewVarsAndVals :: vars_and_vals().

--- a/lib/common_test/src/ct_snmp.erl
+++ b/lib/common_test/src/ct_snmp.erl
@@ -39,10 +39,10 @@
 %%% {snmp,
 %%%        %%% Manager config
 %%%        [{start_manager, boolean()}    % Optional - default is true
-%%%        {users, [{user_name(), [call_back_module(), user_data()]}]}, %% Optional 
+%%%        {users, [{user_name(), [call_back_module(), user_data()]}]}, %% Optional
 %%%        {usm_users, [{usm_user_name(), [usm_config()]}]},%% Optional - snmp v3 only
 %%%        % managed_agents is optional 
-%%%        {managed_agents,[{agent_name(), [user_name(), agent_ip(), agent_port(), [agent_config()]]}]},   
+%%%        {managed_agents,[{agent_name(), [user_name(), agent_ip(), agent_port(), [agent_config()]]}]},
 %%%        {max_msg_size, integer()},     % Optional - default is 484
 %%%        {mgr_port, integer()},         % Optional - default is 5000
 %%%        {engine _id, string()},        % Optional - default is "mgrEngine"
@@ -74,7 +74,7 @@
 %%%        {agent_community, [term()] | {data_dir_file, rel_path()}},% Optional
 %%%        {agent_sysinfo,  [term()] | {data_dir_file, rel_path()}}, % Optional
 %%%        {agent_vacm, [term()] | {data_dir_file, rel_path()}},     % Optional
-%%%        {agent_usm, [term()] | {data_dir_file, rel_path()}},      % Optional 
+%%%        {agent_usm, [term()] | {data_dir_file, rel_path()}},      % Optional
 %%%        {agent_notify_def, [term()] | {data_dir_file, rel_path()}},% Optional
 %%%        {agent_target_address_def, [term()] | {data_dir_file, rel_path()}},% Optional
 %%%        {agent_target_param_def, [term()] | {data_dir_file, rel_path()}},% Optional
@@ -107,8 +107,8 @@
 %%% the OTP snmp User's Guide for a list of valid parameters and types). This is 
 %%% done by defining a configuration data variable on the following form:</p>
 %%% <pre>
-%%% {snmp_app, [{manager, [snmp_app_manager_params()]},
-%%%             {agent, [snmp_app_agent_params()]}]}.</pre>
+%%% {snmp_app, [{manager, [SNMPAppManagerParams :: term()]},
+%%%             {agent, [SNMPAppAgentParams :: term()]}]}.</pre>
 %%% 
 %%% <p>A name for the data needs to be allocated in the suite using 
 %%% <code>require</code> (see example above), and this name passed as 
@@ -122,33 +122,51 @@
 -module(ct_snmp).
 
 %%% Common Types
-%%% @type agent_ip() = ip()
-%%% @type manager_ip() = ip()
-%%% @type agent_name() = atom()
-%%% @type ip() = string() | {integer(), integer(), 
-%%% integer(), integer()}
-%%% @type agent_port() = integer()
-%%% @type agent_config() = {Item, Value} 
-%%% @type user_name() = atom() 
-%%% @type usm_user_name() = string() 
-%%% @type usm_config() = {Item, Value}
-%%% @type call_back_module() = atom()
-%%% @type user_data() = term() 
-%%% @type oids() = [oid()]
-%%% @type oid() = [byte()]
-%%% @type snmpreply() = {error_status(), error_index(), varbinds()} 
-%%% @type error_status() = noError | atom() 
-%%% @type error_index() = integer() 
-%%% @type varbinds() = [varbind()] 
-%%% @type varbind() =  term() 
-%%% @type value_type() = o ('OBJECT IDENTIFIER') | i ('INTEGER') | 
-%%% u ('Unsigned32') | g ('Unsigned32') | s ('OCTET STRING') 
-%%% @type varsandvals() = [var_and_val()]
-%%% @type var_and_val() = {oid(), value_type(), value()}
-%%% @type sec_type() = none | minimum | semi
-%%% @type rel_path() = string() 
-%%% @type snmp_app_manager_params() = term()
-%%% @type snmp_app_agent_params() = term()
+-type ip() :: string() | {integer(), integer(), integer(), integer()}.
+-type agent_ip() :: ip().
+-type manager_ip() :: ip().
+-type agent_name() :: atom().
+-type agent_port() :: integer().
+-type agent_config() :: {start_agent, boolean()} |
+                        {agent_sysname, string()} |
+                        {agent_manager_ip, manager_ip()} |
+                        {agent_vsns, list()} |
+                        {agent_trap_udp, integer()} |
+                        {agent_udp, integer()} |
+                        {agent_notify_type, atom()} |
+                        {agent_sec_type, sec_type()} |
+                        {agent_passwd, string()} |
+                        {agent_engine_id, string()} |
+                        {agent_max_msg_size, string()} |
+                        {agent_contexts, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_community, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_sysinfo,  [term()] | {data_dir_file, rel_path()}} |
+                        {agent_vacm, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_usm, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_notify_def, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_target_address_def, [term()] | {data_dir_file, rel_path()}} |
+                        {agent_target_param_def, [term()] | {data_dir_file, rel_path()}}.
+-type user_name() :: atom().
+-type agent() :: {agent_name(), [user_name() | agent_ip() | agent_port() | [agent_config()]]}.
+-type user_data() :: term().
+-type call_back_module() :: atom().
+-type user() :: {user_name(), [call_back_module() | user_data()]}.
+-type usm_user_name() :: string().
+-type usm_config() :: [term()] | {data_dir_file, rel_path()}.
+-type usm_user() :: {usm_user_name(), [usm_config()]}.
+-type oids() :: [oid()].
+-type oid() :: [byte()].
+-type snmpreply() :: {error_status(), error_index(), varbinds()}.
+-type error_status() :: noError | atom().
+-type error_index() :: integer().
+-type varbinds() :: [varbind()].
+-type varbind() :: term().
+-type value_type() :: o | i | u | g | s | b | ip | op | c32 | c64 | tt.
+-type vars_and_vals() :: [var_and_val()].
+-type value() :: term().
+-type var_and_val() :: {oid(), value_type(), value()} | {oid(), value()}.
+-type sec_type() :: none | minimum | semi.
+-type rel_path() :: string().
 
 
 -include("snmp_types.hrl").
@@ -187,13 +205,6 @@
 start(Config, MgrAgentConfName) ->
     start(Config, MgrAgentConfName, undefined).
 
-%%% @spec start(Config, MgrAgentConfName, SnmpAppConfName) -> ok
-%%%      Config = [{Key, Value}] 
-%%%      Key = atom()
-%%%      Value = term()
-%%%      MgrAgentConfName = atom()
-%%%      SnmpConfName = atom()
-%%%
 %%% @doc Starts an snmp manager and/or agent. In the manager case,
 %%% registrations of users and agents as specified by the configuration 
 %%% <code>MgrAgentConfName</code> will be performed. When using snmp
@@ -206,6 +217,11 @@ start(Config, MgrAgentConfName) ->
 %%% to configure the snmp application with parameters such as <code>config</code>,
 %%% <code>mibs</code>, <code>net_if</code>, etc. The values will be merged
 %%% with (and possibly override) default values set by <code>ct_snmp</code>.
+%%% @end
+-spec start(Config, MgrAgentConfName, SnmpAppConfName) -> ok when
+      Config :: agent_config(),
+      MgrAgentConfName :: atom(),
+      SnmpAppConfName :: atom().
 start(Config, MgrAgentConfName, SnmpAppConfName) ->
     StartManager= ct:get_config({MgrAgentConfName, start_manager}, true),
     StartAgent = ct:get_config({MgrAgentConfName, start_agent}, false),
@@ -224,13 +240,10 @@ start(Config, MgrAgentConfName, SnmpAppConfName) ->
     application:start(snmp),
 
     manager_register(StartManager, MgrAgentConfName).
- 
-%%% @spec stop(Config) -> ok
-%%%      Config = [{Key, Value}]
-%%%      Key = atom()
-%%%      Value = term()
-%%%
+
 %%% @doc Stops the snmp manager and/or agent removes all files created.
+-spec stop(Config) -> ok when
+      Config :: agent_config().
 stop(Config) ->
     PrivDir = ?config(priv_dir, Config),
     application:stop(snmp),
@@ -241,43 +254,34 @@ stop(Config) ->
     catch del_dir(MgrDir),
     catch del_dir(ConfDir),
     catch del_dir(DbDir).
-    
-    
-%%% @spec get_values(Agent, Oids, MgrAgentConfName) -> SnmpReply
-%%%
-%%%	 Agent = agent_name()
-%%%      Oids = oids()
-%%%      MgrAgentConfName = atom()
-%%%      SnmpReply = snmpreply()  
-%%%
-%%% @doc Issues a synchronous snmp get request. 
+
+
+%%% @doc Issues a synchronous snmp get request.
+-spec get_values(Agent, Oids, MgrAgentConfName) -> snmpreply() when
+      Agent :: agent_name(),
+      Oids :: oids(),
+      MgrAgentConfName :: atom().
 get_values(Agent, Oids, MgrAgentConfName) ->
     [Uid | _] = agent_conf(Agent, MgrAgentConfName),
     {ok, SnmpReply, _} = snmpm:sync_get2(Uid, target_name(Agent), Oids),
     SnmpReply.
 
-%%% @spec get_next_values(Agent, Oids, MgrAgentConfName) -> SnmpReply 
-%%%
-%%%	 Agent = agent_name()
-%%%      Oids = oids()
-%%%      MgrAgentConfName = atom()
-%%%      SnmpReply = snmpreply()  
-%%%
-%%% @doc Issues a synchronous snmp get next request. 
+%%% @doc Issues a synchronous snmp get next request.
+-spec get_next_values(Agent, Oids, MgrAgentConfName) -> snmpreply() when
+      Agent :: agent_name(),
+      Oids :: oids(),
+      MgrAgentConfName :: atom().
 get_next_values(Agent, Oids, MgrAgentConfName) ->
     [Uid | _] = agent_conf(Agent, MgrAgentConfName),
     {ok, SnmpReply, _} = snmpm:sync_get_next2(Uid, target_name(Agent), Oids),
     SnmpReply.
 
-%%% @spec set_values(Agent, VarsAndVals, MgrAgentConfName, Config) -> SnmpReply
-%%%
-%%%	 Agent = agent_name()
-%%%      Oids = oids()
-%%%      MgrAgentConfName = atom()
-%%%      Config = [{Key, Value}] 
-%%%      SnmpReply = snmpreply()  
-%%%
-%%% @doc Issues a synchronous snmp set request. 
+%%% @doc Issues a synchronous snmp set request.
+-spec set_values(Agent, VarsAndVals, MgrAgentConfName, Config) -> snmpreply() when
+      Agent :: agent_name(),
+      VarsAndVals :: vars_and_vals(),
+      MgrAgentConfName :: atom(),
+      Config :: agent_config().
 set_values(Agent, VarsAndVals, MgrAgentConfName, Config) ->
     PrivDir = ?config(priv_dir, Config),
     [Uid | _] = agent_conf(Agent, MgrAgentConfName),
@@ -293,19 +297,18 @@ set_values(Agent, VarsAndVals, MgrAgentConfName, Config) ->
     end,
     SnmpSetReply.
 
-%%% @spec set_info(Config) -> [{Agent, OldVarsAndVals, NewVarsAndVals}] 
-%%%
-%%%      Config = [{Key, Value}] 
-%%%	 Agent = agent_name()
-%%%      OldVarsAndVals = varsandvals()
-%%%      NewVarsAndVals = varsandvals()
-%%%
 %%% @doc Returns a list of all successful set requests performed in
 %%% the test case in reverse order. The list contains the involved
 %%% user and agent, the value prior to the set and the new value. This
 %%% is intended to facilitate the clean up in the end_per_testcase
 %%% function i.e. the undoing of the set requests and its possible
 %%% side-effects.
+%%% @end
+-spec set_info(Config) -> [{Agent, OldVarsAndVals, NewVarsAndVals}] when
+      Config :: agent_config(),
+      Agent :: agent_name(),
+      OldVarsAndVals :: vars_and_vals(),
+      NewVarsAndVals :: vars_and_vals().
 set_info(Config) ->
     PrivDir = ?config(priv_dir, Config),
     SetLogFile = filename:join(PrivDir, ?CT_SNMP_LOG_FILE),
@@ -317,18 +320,17 @@ set_info(Config) ->
 	    []
     end.
 
-%%% @spec register_users(MgrAgentConfName, Users) -> ok | {error, Reason}
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      Users =  [user()]
-%%%      Reason = term()    
-%%%
 %%% @doc Register the manager entity (=user) responsible for specific agent(s).
 %%% Corresponds to making an entry in users.conf.
 %%%
 %%% <p>This function will try to register the given users, without
 %%% checking if any of them already exist. In order to change an
 %%% already registered user, the user must first be unregistered.</p>
+%%% @end
+-spec register_users(MgrAgentConfName, Users) -> ok | {error,Reason} when
+      MgrAgentConfName :: atom(),
+      Users :: [user()],
+      Reason :: term().
 register_users(MgrAgentConfName, Users) ->
     case setup_users(Users) of
 	ok ->
@@ -342,12 +344,6 @@ register_users(MgrAgentConfName, Users) ->
 	    Error
     end.
 
-%%% @spec register_agents(MgrAgentConfName, ManagedAgents) -> ok | {error, Reason}
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      ManagedAgents = [agent()]
-%%%      Reason = term()    
-%%%
 %%% @doc Explicitly instruct the manager to handle this agent.
 %%% Corresponds to making an entry in agents.conf 
 %%%
@@ -355,6 +351,11 @@ register_users(MgrAgentConfName, Users) ->
 %%% without checking if any of them already exist. In order to change
 %%% an already registered managed agent, the agent must first be
 %%% unregistered.</p>
+%%% @end
+-spec register_agents(MgrAgentConfName, ManagedAgents) -> ok | {error,Reason} when
+      MgrAgentConfName :: atom(),
+      ManagedAgents :: [agent()],
+      Reason :: term().
 register_agents(MgrAgentConfName, ManagedAgents) ->
     case setup_managed_agents(MgrAgentConfName,ManagedAgents) of
 	ok ->
@@ -369,18 +370,17 @@ register_agents(MgrAgentConfName, ManagedAgents) ->
 	    Error
     end.
 
-%%% @spec register_usm_users(MgrAgentConfName, UsmUsers) ->  ok | {error, Reason}
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      UsmUsers = [usm_user()]
-%%%      Reason = term()    
-%%%
 %%% @doc Explicitly instruct the manager to handle this USM user.
 %%% Corresponds to making an entry in usm.conf 
 %%%
 %%% <p>This function will try to register the given users, without
 %%% checking if any of them already exist. In order to change an
 %%% already registered user, the user must first be unregistered.</p>
+%%% @end
+-spec register_usm_users(MgrAgentConfName, UsmUsers) -> ok | {error,Reason} when
+      MgrAgentConfName :: atom(),
+      UsmUsers :: [usm_user()],
+      Reason :: term().
 register_usm_users(MgrAgentConfName, UsmUsers) ->
     EngineID = ct:get_config({MgrAgentConfName, engine_id}, ?ENGINE_ID),
     case setup_usm_users(UsmUsers, EngineID) of
@@ -395,23 +395,17 @@ register_usm_users(MgrAgentConfName, UsmUsers) ->
 	    Error
     end.
 
-%%% @spec unregister_users(MgrAgentConfName) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      Reason = term()
-%%%
 %%% @doc Unregister all users.
+-spec unregister_users(MgrAgentConfName) -> ok when
+      MgrAgentConfName :: atom().
 unregister_users(MgrAgentConfName) ->
     Users = [Id || {Id,_} <- ct:get_config({MgrAgentConfName, users},[])],
     unregister_users(MgrAgentConfName,Users).
 
-%%% @spec unregister_users(MgrAgentConfName,Users) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      Users = [user_name()]
-%%%      Reason = term()
-%%%
 %%% @doc Unregister the given users.
+-spec unregister_users(MgrAgentConfName, Users) -> ok when
+      MgrAgentConfName :: atom(),
+      Users :: [user_name()].
 unregister_users(MgrAgentConfName,Users) ->
     takedown_users(Users),
     SnmpVals = ct:get_config(MgrAgentConfName),
@@ -424,25 +418,19 @@ unregister_users(MgrAgentConfName,Users) ->
     ct_config:update_config(MgrAgentConfName, NewSnmpVals),
     ok.
 
-%%% @spec unregister_agents(MgrAgentConfName) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      Reason = term()
-%%%
 %%% @doc  Unregister all managed agents.
-unregister_agents(MgrAgentConfName) ->    
+-spec unregister_agents(MgrAgentConfName) -> ok when
+      MgrAgentConfName :: atom().
+unregister_agents(MgrAgentConfName) ->
     ManagedAgents =  [AgentName ||
 			 {AgentName, _} <-
 			     ct:get_config({MgrAgentConfName,managed_agents},[])],
     unregister_agents(MgrAgentConfName,ManagedAgents).
 
-%%% @spec unregister_agents(MgrAgentConfName,ManagedAgents) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      ManagedAgents = [agent_name()]
-%%%      Reason = term()
-%%%
 %%% @doc  Unregister the given managed agents.
+-spec unregister_agents(MgrAgentConfName, ManagedAgents) -> ok when
+      MgrAgentConfName :: atom(),
+      ManagedAgents :: [agent_name()].
 unregister_agents(MgrAgentConfName,ManagedAgents) ->
     takedown_managed_agents(MgrAgentConfName, ManagedAgents),
     SnmpVals = ct:get_config(MgrAgentConfName),
@@ -456,23 +444,17 @@ unregister_agents(MgrAgentConfName,ManagedAgents) ->
     ct_config:update_config(MgrAgentConfName, NewSnmpVals),
     ok.
 
-%%% @spec unregister_usm_users(MgrAgentConfName) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      Reason = term()
-%%%
 %%% @doc Unregister all usm users.
+-spec unregister_usm_users(MgrAgentConfName) -> ok when
+      MgrAgentConfName :: atom().
 unregister_usm_users(MgrAgentConfName) ->
     UsmUsers = [Id || {Id,_} <- ct:get_config({MgrAgentConfName, usm_users},[])],
     unregister_usm_users(MgrAgentConfName,UsmUsers).
 
-%%% @spec unregister_usm_users(MgrAgentConfName,UsmUsers) ->  ok
-%%%
-%%%      MgrAgentConfName = atom()
-%%%      UsmUsers = [usm_user_name()]
-%%%      Reason = term()
-%%%
 %%% @doc Unregister the given usm users.
+-spec unregister_usm_users(MgrAgentConfName, UsmUsers) -> ok when
+      MgrAgentConfName :: atom(),
+      UsmUsers :: [usm_user_name()].
 unregister_usm_users(MgrAgentConfName,UsmUsers) ->
     EngineID = ct:get_config({MgrAgentConfName, engine_id}, ?ENGINE_ID),
     takedown_usm_users(UsmUsers,EngineID),
@@ -487,23 +469,19 @@ unregister_usm_users(MgrAgentConfName,UsmUsers) ->
     ct_config:update_config(MgrAgentConfName, NewSnmpVals),
     ok.
 
-%%% @spec load_mibs(Mibs) -> ok | {error, Reason}
-%%%
-%%%      Mibs = [MibName]
-%%%      MibName = string()
-%%%      Reason = term()
-%%%
 %%% @doc Load the mibs into the agent 'snmp_master_agent'.
-load_mibs(Mibs) ->       
+-spec load_mibs(Mibs) -> ok | {error,Reason} when
+      Mibs :: [MibName],
+      MibName :: string(),
+      Reason :: term().
+load_mibs(Mibs) ->
     snmpa:load_mibs(snmp_master_agent, Mibs).
- 
-%%% @spec unload_mibs(Mibs) -> ok | {error, Reason}
-%%%
-%%%      Mibs = [MibName]
-%%%      MibName = string()
-%%%      Reason = term()
-%%%
+
 %%% @doc Unload the mibs from the agent 'snmp_master_agent'.
+-spec unload_mibs(Mibs) -> ok | {error,Reason} when
+      Mibs :: [MibName],
+      MibName :: string(),
+      Reason :: term().
 unload_mibs(Mibs) ->
     snmpa:unload_mibs(snmp_master_agent, Mibs).
 

--- a/lib/common_test/src/ct_ssh.erl
+++ b/lib/common_test/src/ct_ssh.erl
@@ -34,7 +34,6 @@
 %%% connection (i.e. may be used as config elements):</p> 
 %%%
 %%% <pre>
-%%%
 %%%  [{ConnType, Addr},
 %%%   {port, Port},
 %%%   {user, UserName}
@@ -50,11 +49,6 @@
 %%%
 %%% <p>All timeout parameters in ct_ssh functions are values in
 %%% milliseconds.</p>
-%%%
-%%% @type connection() = handle() | ct:target_name()
-%%% @type handle() = ct_gen_conn:handle(). Handle for a specific
-%%% SSH/SFTP connection.
-%%% @type ssh_sftp_return() = term(). A return value from an ssh_sftp function.
 
 -module(ct_ssh).
 
@@ -92,6 +86,13 @@
 
 -define(DEFAULT_TIMEOUT, 10000).
 
+-type connection() :: handle() | ct:target_name().
+-type handle() :: ct_gen_conn:handle().
+%% Handle for a specific SSH/SFTP connection.
+-type ssh_sftp_return() :: term().
+%% A return value from an ssh_sftp function.
+-type ssh_connect_options() :: proplists:proplist().
+
 -record(state, {ssh_ref, conn_type, target}).
 
 
@@ -99,34 +100,40 @@
 %%%------------------------ SSH COMMANDS ---------------------------
 
 %%%-----------------------------------------------------------------
-%%% @spec connect(KeyOrName) -> {ok,Handle} | {error,Reason}
-%%% @equiv connect(KeyOrName,host,[])
+%%% @equiv connect(KeyOrName, host, [])
+-spec connect(KeyOrName) -> {ok,Handle} | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      Handle :: handle(),
+      Reason :: term().
 connect(KeyOrName) ->
     connect(KeyOrName, host).
 
+-spec connect(KeyOrName, ConnType) -> {ok, Handle} | {error, Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      ConnType :: ssh | sftp | host,
+      Handle :: handle(),
+      Reason :: term();
+             (KeyOrName, ExtraOpts) -> {ok, Handle} | {error, Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      ExtraOpts :: ssh_connect_options(),
+      Handle :: handle(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec connect(KeyOrName,ConnType) -> {ok,Handle} | {error,Reason}
-%%% @equiv connect(KeyOrName,ConnType,[])
+%%% @equiv connect(KeyOrName, ConnType, [])
 connect(KeyOrName, ConnType) when is_atom(ConnType) ->
     connect(KeyOrName, ConnType, []);
-
 %%%-----------------------------------------------------------------
-%%% @spec connect(KeyOrName,ExtraOpts) -> {ok,Handle} | {error,Reason}
-%%% @equiv connect(KeyOrName,host,ExtraOpts)
+%%% @equiv connect(KeyOrName, host, ExtraOpts)
 connect(KeyOrName, ExtraOpts) when is_list(ExtraOpts) ->
     connect(KeyOrName, host, ExtraOpts).
 
 %%%-----------------------------------------------------------------
-%%% @spec connect(KeyOrName,ConnType,ExtraOpts) -> 
-%%%          {ok,Handle} | {error,Reason}
-%%%      KeyOrName = Key | Name
-%%%      Key = atom()
-%%%      Name = ct:target_name()
-%%%      ConnType = ssh | sftp | host
-%%%      ExtraOpts = ssh_connect_options()
-%%%      Handle = handle()
-%%%      Reason = term()
-%%%
 %%% @doc Open an SSH or SFTP connection using the information
 %%%      associated with <code>KeyOrName</code>. 
 %%%
@@ -154,8 +161,17 @@ connect(KeyOrName, ExtraOpts) when is_list(ExtraOpts) ->
 %%%      The extra options will override any existing options with the
 %%%      same key in the config data. For details on valid SSH
 %%%      options, see the documentation for the OTP ssh application.</p>
-%%%
+%%% @end
 %%% @see ct:require/2
+-spec connect(KeyOrName, ConnType, ExtraOpts) ->
+                     {ok,Handle} | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      ConnType :: ssh | sftp | host,
+      ExtraOpts :: ssh_connect_options(),
+      Handle :: handle(),
+      Reason :: term().
 connect(KeyOrName, ConnType, ExtraOpts) ->
     case ct:get_config(KeyOrName) of
 	undefined ->
@@ -231,11 +247,10 @@ connect(KeyOrName, ConnType, ExtraOpts) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec disconnect(SSH) -> ok | {error,Reason}
-%%%      SSH = connection()
-%%%      Reason = term()
-%%%
 %%% @doc Close an SSH/SFTP connection.
+-spec disconnect(SSH) -> ok | {error,Reason} when
+      SSH :: connection(),
+      Reason :: term().
 disconnect(SSH) ->
     case get_handle(SSH) of
 	{ok,Pid} ->
@@ -251,29 +266,30 @@ disconnect(SSH) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec session_open(SSH) -> {ok,ChannelId} | {error, Reason}
-%%% @equiv session_open(SSH,DefaultTimeout) 
+%%% @equiv session_open(SSH, DefaultTimeout)
+-spec session_open(SSH) -> {ok,ChannelId} | {error, Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Reason :: term().
 session_open(SSH) ->
     call(SSH, {session_open,?DEFAULT_TIMEOUT}).
 
 %%%-----------------------------------------------------------------
-%%% @spec session_open(SSH,Timeout) -> {ok,ChannelId} | {error, Reason}
-%%%      SSH = connection()
-%%%      Timeout = integer()
-%%%      ChannelId = integer()
-%%%      Reason = term()
-%%%
 %%% @doc Opens a channel for an SSH session.
+-spec session_open(SSH, Timeout) -> {ok,ChannelId} | {error, Reason} when
+      SSH :: connection(),
+      Timeout :: integer(),
+      ChannelId :: integer(),
+      Reason :: term().
 session_open(SSH, Timeout) ->
     call(SSH, {session_open,Timeout}).
 
 %%%-----------------------------------------------------------------
-%%% @spec session_close(SSH,ChannelId) -> ok | {error, Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      Reason = term()
-%%%
 %%% @doc Closes an SSH session channel.
+-spec session_close(SSH, ChannelId) -> ok | {error, Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Reason :: term().
 session_close(SSH, ChannelId) ->
     call(SSH, {session_close,ChannelId}).
 
@@ -283,71 +299,80 @@ session_close(SSH, ChannelId) ->
 exec(SSH, Command) ->
     exec(SSH, undefined, Command, ?DEFAULT_TIMEOUT).
 
+-spec exec(SSH, Command, Timeout) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      Command :: string(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term();
+          (SSH, ChannelId, Command) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Command :: string(),
+      Data :: list(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec exec(SSH,Command,Timeout) -> {ok,Data} | {error,Reason}
-%%%      SSH = connection()
-%%%      Command = string()
-%%%      Timeout = integer()
-%%%      Data = list()
-%%%      Reason = term()
-%%% 
 %%% @doc Requests server to perform <code>Command</code>. A session
 %%%      channel is opened automatically for the request.
 %%%      <code>Data</code> is received from the server as a result
 %%%      of the command.
+%%% @end
 exec(SSH, Command, Timeout) when is_list(Command) ->
     exec(SSH, undefined, Command, Timeout);
-
 %%%-----------------------------------------------------------------
-%%% @spec exec(SSH,ChannelId,Command) -> {ok,Data} | {error,Reason}
-%%% @equiv exec(SSH,ChannelId,Command,DefaultTimeout)
+%%% @equiv exec(SSH, ChannelId, Command, DefaultTimeout)
 exec(SSH, ChannelId, Command) when is_integer(ChannelId) ->
     exec(SSH, ChannelId, Command, ?DEFAULT_TIMEOUT).
 
 %%%-----------------------------------------------------------------
-%%% @spec exec(SSH,ChannelId,Command,Timeout) -> {ok,Data} | {error,Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      Command = string()
-%%%      Timeout = integer()
-%%%      Data = list()
-%%%      Reason = term()
-%%% 
 %%% @doc Requests server to perform <code>Command</code>. A previously
 %%%      opened session channel is used for the request.
 %%%      <code>Data</code> is received from the server as a result
 %%%      of the command.
+%% @end
+-spec exec(SSH, ChannelId, Command, Timeout) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Command :: string(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term().
 exec(SSH, ChannelId, Command, Timeout) ->
     call(SSH, {exec,ChannelId,Command,Timeout}).
 
 %%%-----------------------------------------------------------------
-%%% @spec receive_response(SSH,ChannelId) -> {ok,Data} | {error,Reason}
-%%% @equiv receive_response(SSH,ChannelId,close)
+%%% @equiv receive_response(SSH, ChannelId, close)
+-spec receive_response(SSH, ChannelId) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Data :: list(),
+      Reason :: term().
 receive_response(SSH, ChannelId) ->
     receive_response(SSH, ChannelId, close, ?DEFAULT_TIMEOUT).
 
+-spec receive_response(SSH, ChannelId, End) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Data :: list(),
+      Reason :: term();
+                      (SSH, ChannelId, Timeout) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec receive_response(SSH,ChannelId,End) -> {ok,Data} | {error,Reason}
-%%% @equiv receive_response(SSH,ChannelId,End,DefaultTimeout)
+%%% @equiv receive_response(SSH, ChannelId, End, DefaultTimeout)
 receive_response(SSH, ChannelId, End) when is_function(End) ->
     receive_response(SSH, ChannelId, End, ?DEFAULT_TIMEOUT);
-
 %%%-----------------------------------------------------------------
-%%% @spec receive_response(SSH,ChannelId,Timeout) -> {ok,Data} | {error,Reason}
-%%% @equiv receive_response(SSH,ChannelId,close,Timeout)
+%%% @equiv receive_response(SSH, ChannelId, close, Timeout)
 receive_response(SSH, ChannelId, Timeout) when is_integer(Timeout) ->
     receive_response(SSH, ChannelId, close, Timeout).
 
 %%%-----------------------------------------------------------------
-%%% @spec receive_response(SSH,ChannelId,End,Timeout) -> 
-%%%                    {ok,Data} | {timeout,Data} | {error,Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      End = Fun | close | timeout
-%%%      Timeout = integer()
-%%%      Data = list()
-%%%      Reason = term()
-%%%      
 %%% @doc Receives expected data from server on the specified
 %%%      session channel. 
 %%%
@@ -367,125 +392,188 @@ receive_response(SSH, ChannelId, Timeout) when is_integer(Timeout) ->
 %%%      <code>false</code> to wait for more data from the server.
 %%%      (Note that even if a fun is supplied, the function returns
 %%%      immediately if the server closes the channel).</p>
+%%% @end
+-spec receive_response(SSH, ChannelId, End, Timeout) ->
+                              {ok,Data} | {timeout,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term().
 receive_response(SSH, ChannelId, End, Timeout) ->
     call(SSH, {receive_response,ChannelId,End,Timeout}).
 
 %%%-----------------------------------------------------------------
-%%% @spec send(SSH,ChannelId,Data) -> ok | {error,Reason}
-%%% @equiv send(SSH,ChannelId,0,Data,DefaultTimeout)
+%%% @equiv send(SSH, ChannelId, 0, Data, DefaultTimeout)
+-spec send(SSH, ChannelId, Data) -> ok | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Data :: list(),
+      Reason :: term().
 send(SSH, ChannelId, Data) ->
     send(SSH, ChannelId, 0, Data, ?DEFAULT_TIMEOUT).
 
+-spec send(SSH, ChannelId, Data, Timeout) -> ok | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term();
+          (SSH, ChannelId, Type, Data) -> ok | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      Data :: list(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec send(SSH,ChannelId,Data,Timeout) -> ok | {error,Reason}
-%%% @equiv send(SSH,ChannelId,0,Data,Timeout)
+%%% @equiv send(SSH, ChannelId, 0, Data, Timeout)
 send(SSH, ChannelId, Data, Timeout) when is_integer(Timeout) ->
     send(SSH, ChannelId, 0, Data, Timeout);
-
 %%%-----------------------------------------------------------------
-%%% @spec send(SSH,ChannelId,Type,Data) -> ok | {error,Reason}
-%%% @equiv send(SSH,ChannelId,Type,Data,DefaultTimeout)
+%%% @equiv send(SSH, ChannelId, Type, Data, DefaultTimeout)
 send(SSH, ChannelId, Type, Data) when is_integer(Type) ->
     send(SSH, ChannelId, Type, Data, ?DEFAULT_TIMEOUT).
 
 %%%-----------------------------------------------------------------
-%%% @spec send(SSH,ChannelId,Type,Data,Timeout) -> ok | {error,Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      Type = integer()
-%%%      Data = list()
-%%%      Timeout = integer()
-%%%      Reason = term()
-%%% 
 %%% @doc Send data to server on specified session channel.
+-spec send(SSH, ChannelId, Type, Data, Timeout) -> ok | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      Data :: list(),
+      Timeout :: integer(),
+      Reason :: term().
 send(SSH, ChannelId, Type, Data, Timeout) ->
     call(SSH, {send,ChannelId,Type,Data,Timeout}).
 
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Data) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,Data,close)
+%%% @equiv send_and_receive(SSH, ChannelId, Data, close)
+-spec send_and_receive(SSH, ChannelId, Data) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Data :: list(),
+      Reason :: term().
 send_and_receive(SSH, ChannelId, Data) ->
     send_and_receive(SSH, ChannelId, 0, Data, close, ?DEFAULT_TIMEOUT).
 
+-spec send_and_receive(SSH, ChannelId, Data, End) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Data :: list(),
+      Reason :: term();
+                      (SSH, ChannelId, Data, Timeout) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term();
+                      (SSH, ChannelId, Type, Data) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      Data :: list(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Data,End) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,0,Data,End,DefaultTimeout)
+%%% @equiv send_and_receive(SSH, ChannelId, 0, Data, End, DefaultTimeout)
 send_and_receive(SSH, ChannelId, Data, End) when is_function(End) ->
     send_and_receive(SSH, ChannelId, 0, Data, End, ?DEFAULT_TIMEOUT);
-
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Data,Timeout) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,0,Data,close,Timeout)
+%%% @equiv send_and_receive(SSH, ChannelId, 0, Data, close, Timeout)
 send_and_receive(SSH, ChannelId, Data, Timeout) when is_integer(Timeout) ->
     send_and_receive(SSH, ChannelId, 0, Data, close, Timeout);
-
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Type,Data) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,Type,Data,close,DefaultTimeout)
+%%% @equiv send_and_receive(SSH, ChannelId, Type, Data, close, DefaultTimeout)
 send_and_receive(SSH, ChannelId, Type, Data) when is_integer(Type) ->
     send_and_receive(SSH, ChannelId, Type, Data, close, ?DEFAULT_TIMEOUT).
 
+-spec send_and_receive(SSH, ChannelId, Data, End, Timeout) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term();
+                      (SSH, ChannelId, Type, Data, Timeout) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      Timeout :: integer(),
+      Data :: list(),
+      Reason :: term();
+                      (SSH, ChannelId, Type, Data, End) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Data :: list(),
+      Reason :: term().
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Data,End,Timeout) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,0,Data,End,Timeout)
+%%% @equiv send_and_receive(SSH, ChannelId, 0, Data, End, Timeout)
 send_and_receive(SSH, ChannelId, Data, End, Timeout) when is_integer(Timeout) ->
     send_and_receive(SSH, ChannelId, 0, Data, End, Timeout);
-
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Type,Data,Timeout) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,Type,Data,close,Timeout)
+%%% @equiv send_and_receive(SSH, ChannelId, Type, Data, close, Timeout)
 send_and_receive(SSH, ChannelId, Type, Data, Timeout) when is_integer(Type) ->
     send_and_receive(SSH, ChannelId, Type, Data, close, Timeout);
-
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Type,Data,End) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%% @equiv send_and_receive(SSH,ChannelId,Type,Data,End,DefaultTimeout)
+%%% @equiv send_and_receive(SSH, ChannelId, Type, Data, End, DefaultTimeout)
 send_and_receive(SSH, ChannelId, Type, Data, End) when is_function(End) ->
     send_and_receive(SSH, ChannelId, Type, Data, End, ?DEFAULT_TIMEOUT).
 
 %%%-----------------------------------------------------------------
-%%% @spec send_and_receive(SSH,ChannelId,Type,Data,End,Timeout) -> 
-%%%                   {ok,Data} | {error,Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      Type = integer()
-%%%      Data = list()
-%%%      End = Fun | close | timeout
-%%%      Timeout = integer()
-%%%      Reason = term()
-%%%
 %%% @doc Send data to server on specified session channel and wait
 %%%      to receive the server response. 
 %%%
 %%%      <p>See <code>receive_response/4</code> for details on the 
 %%%      <code>End</code> argument.</p>
+%%% @end
+-spec send_and_receive(SSH, ChannelId, Type, Data, End, Timeout) ->
+                              {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Type :: integer(),
+      Data :: list(),
+      End :: Fun | close | timeout,
+      Fun :: fun((ssh_connection:ssh_event_msg()) -> boolean()),
+      Timeout :: integer(),
+      Reason :: term().
 send_and_receive(SSH, ChannelId, Type, Data, End, Timeout) ->
     call(SSH, {send_and_receive,ChannelId,Type,Data,End,Timeout}).
 
 %%%-----------------------------------------------------------------
-%%% @spec subsystem(SSH,ChannelId,Subsystem) -> Status | {error,Reason}
-%%% @equiv subsystem(SSH,ChannelId,Subsystem,DefaultTimeout)
+%%% @equiv subsystem(SSH, ChannelId, Subsystem, DefaultTimeout)
+-spec subsystem(SSH, ChannelId, Subsystem) -> Status | {error, Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Subsystem :: string(),
+      Status :: success | failure,
+      Reason :: term().
 subsystem(SSH, ChannelId, Subsystem) ->
     subsystem(SSH, ChannelId, Subsystem, ?DEFAULT_TIMEOUT).
 
 %%%-----------------------------------------------------------------
-%%% @spec subsystem(SSH,ChannelId,Subsystem,Timeout) -> 
-%%%             Status | {error,Reason}
-%%%      SSH = connection()
-%%%      ChannelId = integer()
-%%%      Subsystem = string()
-%%%      Timeout = integer()
-%%%      Status = success | failure
-%%%      Reason = term()
-%%% 
 %%% @doc Sends a request to execute a predefined subsystem.
+-spec subsystem(SSH, ChannelId, Subsystem, Timeout) ->
+                       Status | {error,Reason} when
+      SSH :: connection(),
+      ChannelId :: integer(),
+      Subsystem :: string(),
+      Timeout :: integer(),
+      Status :: success | failure,
+      Reason :: term().
 subsystem(SSH, ChannelId, Subsystem, Timeout) ->
     call(SSH, {subsystem,ChannelId,Subsystem,Timeout}).
 
@@ -494,438 +582,502 @@ subsystem(SSH, ChannelId, Subsystem, Timeout) ->
 %%%------------------------ SFTP COMMANDS --------------------------
 
 %%%-----------------------------------------------------------------
-%%% @spec sftp_connect(SSH) -> {ok,Server} | {error,Reason}
-%%%      SSH = connection()
-%%%      Server = pid()
-%%%      Reason = term()
 %%% @doc Starts an SFTP session on an already existing SSH connection.
 %%%      <code>Server</code> identifies the new session and must be
 %%%      specified whenever SFTP requests are to be sent.
+%%% @end
+-spec sftp_connect(SSH) -> {ok,Server} | {error,Reason} when
+      SSH :: connection(),
+      Server :: pid(),
+      Reason :: term().
 sftp_connect(SSH) ->
     call(SSH, sftp_connect).
 
 %%%-----------------------------------------------------------------
-%%% @spec read_file(SSH, File) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_file(SSH, File) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      File :: string(),
+      Reason :: term().
 read_file(SSH, File) ->
     call(SSH, {read_file,sftp,File}).
 %%%-----------------------------------------------------------------
-%%% @spec read_file(SSH, Server, File) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_file(SSH, Server, File) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      File :: string(),
+      Reason :: term().
 read_file(SSH, Server, File) ->
     call(SSH, {read_file,Server,File}).
 
 %%%-----------------------------------------------------------------
-%%% @spec write_file(SSH, File, Iolist) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write_file(SSH, File, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      File :: string(),
+      Data :: iolist(),
+      Reason :: term().
 write_file(SSH, File, Iolist) ->
     call(SSH, {write_file,sftp,File,Iolist}).
 %%%-----------------------------------------------------------------
-%%% @spec write_file(SSH, Server, File, Iolist) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write_file(SSH, Server, File, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      File :: string(),
+      Data :: iolist(),
+      Reason :: term().
 write_file(SSH, Server, File, Iolist) ->
     call(SSH, {write_file,Server,File,Iolist}).
 
 %%%-----------------------------------------------------------------
-%%% @spec list_dir(SSH, Path) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec list_dir(SSH, Path) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Path :: string(),
+      Reason :: term().
 list_dir(SSH, Path) ->
     call(SSH, {list_dir,sftp,Path}).
 %%%-----------------------------------------------------------------
-%%% @spec list_dir(SSH, Server, Path) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec list_dir(SSH, Server, Path) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Path :: string(),
+      Reason :: term().
 list_dir(SSH, Server, Path) ->
     call(SSH, {list_dir,Server,Path}).
 
 %%%-----------------------------------------------------------------
-%%% @spec open(SSH, File, Mode) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec open(SSH, File, Mode) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      File :: string(),
+      Mode :: [read | write | creat | trunc | append | binary],
+      Reason :: term().
 open(SSH, File, Mode) ->
     call(SSH, {open,sftp,File,Mode}).
 %%%-----------------------------------------------------------------
-%%% @spec open(SSH, Server, File, Mode) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec open(SSH, Server, File, Mode) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      File :: string(),
+      Mode :: [read | write | creat | trunc | append | binary],
+      Reason :: term().
 open(SSH, Server, File, Mode) ->
     call(SSH, {open,Server,File,Mode}).
 
 %%%-----------------------------------------------------------------
-%%% @spec opendir(SSH, Path) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec opendir(SSH, Path) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Path :: string(),
+      Reason :: term().
 opendir(SSH, Path) ->
     call(SSH, {opendir,sftp,Path}).
 %%%-----------------------------------------------------------------
-%%% @spec opendir(SSH, Server, Path) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec opendir(SSH, Server, Path) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Path :: string(),
+      Reason :: term().
 opendir(SSH, Server, Path) ->
     call(SSH, {opendir,Server,Path}).
 
 %%%-----------------------------------------------------------------
-%%% @spec close(SSH, Handle) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec close(SSH, Handle) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Reason :: term().
 close(SSH, Handle) ->
     call(SSH, {close,sftp,Handle}).
 %%%-----------------------------------------------------------------
-%%% @spec close(SSH, Server, Handle) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec close(SSH, Server, Handle) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Reason :: term().
 close(SSH, Server, Handle) ->
     call(SSH, {close,Server,Handle}).
 
 %%%-----------------------------------------------------------------
-%%% @spec read(SSH, Handle, Len) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read(SSH, Handle, Len) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Len :: integer(),
+      Reason :: term().
 read(SSH, Handle, Len) ->
     call(SSH, {read,sftp,Handle,Len}).
 %%%-----------------------------------------------------------------
-%%% @spec read(SSH, Server, Handle, Len) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read(SSH, Server, Handle, Len) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Len :: integer(),
+      Reason :: term().
 read(SSH, Server, Handle, Len) ->
     call(SSH, {read,Server,Handle,Len}).
 
 %%%-----------------------------------------------------------------
-%%% @spec pread(SSH, Handle, Position, Length) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec pread(SSH, Handle, Position, Length) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Position :: integer(),
+      Length :: integer(),
+      Reason :: term().
 pread(SSH, Handle, Position, Length) ->
     call(SSH, {pread,sftp,Handle,Position,Length}).
 %%%-----------------------------------------------------------------
-%%% @spec pread(SSH, Server, Handle, Position, Length) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec pread(SSH, Server, Handle, Position, Length) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Position :: integer(),
+      Length :: integer(),
+      Reason :: term().
 pread(SSH, Server, Handle, Position, Length) ->
     call(SSH, {pread,Server,Handle,Position,Length}).
 
 %%%-----------------------------------------------------------------
-%%% @spec aread(SSH, Handle, Len) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec aread(SSH, Handle, Len) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Len :: integer(),
+      Reason :: term().
 aread(SSH, Handle, Len) ->
     call(SSH, {aread,sftp,Handle,Len}).
 %%%-----------------------------------------------------------------
-%%% @spec aread(SSH, Server, Handle, Len) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec aread(SSH, Server, Handle, Len) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Len :: integer(),
+      Reason :: term().
 aread(SSH, Server, Handle, Len) ->
     call(SSH, {aread,Server,Handle,Len}).
 
 %%%-----------------------------------------------------------------
-%%% @spec apread(SSH, Handle, Position, Length) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec apread(SSH, Handle, Position, Length) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Position :: integer(),
+      Length :: integer(),
+      Reason :: term().
 apread(SSH, Handle, Position, Length) ->
     call(SSH, {apread,sftp,Handle,Position,Length}).
 %%%-----------------------------------------------------------------
-%%% @spec apread(SSH, Server, Handle, Position, Length) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec apread(SSH, Server, Handle, Position, Length) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Position :: integer(),
+      Length :: integer(),
+      Reason :: term().
 apread(SSH, Server, Handle, Position, Length) ->
     call(SSH, {apread,Server,Handle,Position,Length}).
 
 %%%-----------------------------------------------------------------
-%%% @spec write(SSH, Handle, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write(SSH, Handle, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Data :: iolist(),
+      Reason :: term().
 write(SSH, Handle, Data) ->
     call(SSH, {write,sftp,Handle,Data}).
 %%%-----------------------------------------------------------------
-%%% @spec write(SSH, Server, Handle, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write(SSH, Server, Handle, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Data :: iolist(),
+      Reason :: term().
 write(SSH, Server, Handle, Data) ->
     call(SSH, {write,Server,Handle,Data}).
 
 %%%-----------------------------------------------------------------
-%%% @spec pwrite(SSH, Handle, Position, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec pwrite(SSH, Handle, Position, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Position :: integer(),
+      Data :: iolist(),
+      Reason :: term().
 pwrite(SSH, Handle, Position, Data) ->
     call(SSH, {pwrite,sftp,Handle,Position,Data}).
 %%%-----------------------------------------------------------------
-%%% @spec pwrite(SSH, Server, Handle, Position, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec pwrite(SSH, Server, Handle, Position, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Position :: integer(),
+      Data :: iolist(),
+      Reason :: term().
 pwrite(SSH, Server, Handle, Position, Data) ->
     call(SSH, {pwrite,Server,Handle,Position,Data}).
 
 %%%-----------------------------------------------------------------
-%%% @spec awrite(SSH, Handle, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec awrite(SSH, Handle, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Data :: iolist(),
+      Reason :: term().
 awrite(SSH, Handle, Data) ->
     call(SSH, {awrite,sftp,Handle, Data}).
 %%%-----------------------------------------------------------------
-%%% @spec awrite(SSH, Server, Handle, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec awrite(SSH, Server, Handle, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Data :: iolist(),
+      Reason :: term().
 awrite(SSH, Server, Handle, Data) ->
     call(SSH, {awrite,Server,Handle, Data}).
 
 %%%-----------------------------------------------------------------
-%%% @spec apwrite(SSH, Handle, Position, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec apwrite(SSH, Handle, Position, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Position :: integer(),
+      Data :: iolist(),
+      Reason :: term().
 apwrite(SSH, Handle, Position, Data) ->
     call(SSH, {apwrite,sftp,Handle,Position,Data}).
 %%%-----------------------------------------------------------------
-%%% @spec apwrite(SSH, Server, Handle, Position, Data) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec apwrite(SSH, Server, Handle, Position, Data) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Position :: integer(),
+      Data :: iolist(),
+      Reason :: term().
 apwrite(SSH, Server, Handle, Position, Data) ->
     call(SSH, {apwrite,Server,Handle,Position,Data}).
 
 %%%-----------------------------------------------------------------
-%%% @spec position(SSH, Handle, Location) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec position(SSH, Handle, Location) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Location :: Offset | {bof, Offset} | {cur, Offset} | {eof, Offset} | bof | cur | eof,
+      Offset :: integer(),
+      Reason :: term().
 position(SSH, Handle, Location) ->
     call(SSH, {position,sftp,Handle,Location}).
 %%%-----------------------------------------------------------------
-%%% @spec position(SSH, Server, Handle, Location) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec position(SSH, Server, Handle, Location) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Location :: Offset | {bof, Offset} | {cur, Offset} | {eof, Offset} | bof | cur | eof,
+      Offset :: integer(),
+      Reason :: term().
 position(SSH, Server, Handle, Location) ->
     call(SSH, {position,Server,Handle,Location}).
 
 %%%-----------------------------------------------------------------
-%%% @spec read_file_info(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_file_info(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 read_file_info(SSH, Name) ->
     call(SSH, {read_file_info,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec read_file_info(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_file_info(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 read_file_info(SSH, Server, Name) ->
     call(SSH, {read_file_info,Server,Name}).
 
 %%%-----------------------------------------------------------------
-%%% @spec get_file_info(SSH, Handle) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec get_file_info(SSH, Handle) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Handle :: term(),
+      Reason :: term().
 get_file_info(SSH, Handle) ->
     call(SSH, {get_file_info,sftp,Handle}).
 %%%-----------------------------------------------------------------
-%%% @spec get_file_info(SSH, Server, Handle) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec get_file_info(SSH, Server, Handle) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Handle :: term(),
+      Reason :: term().
 get_file_info(SSH, Server, Handle) ->
     call(SSH, {get_file_info,Server,Handle}).
 
 %%%-----------------------------------------------------------------
-%%% @spec read_link_info(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_link_info(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 read_link_info(SSH, Name) ->
     call(SSH, {read_link_info,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec read_link_info(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_link_info(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 read_link_info(SSH, Server, Name) ->
     call(SSH, {read_link_info,Server,Name}).
 
 %%%-----------------------------------------------------------------
-%%% @spec write_file_info(SSH, Name, Info) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write_file_info(SSH, Name, Info) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Info :: file:file_info(),
+      Reason :: term().
 write_file_info(SSH, Name, Info) ->
     call(SSH, {write_file_info,sftp,Name,Info}).
 %%%-----------------------------------------------------------------
-%%% @spec write_file_info(SSH, Server, Name, Info) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec write_file_info(SSH, Server, Name, Info) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Info :: file:file_info(),
+      Reason :: term().
 write_file_info(SSH, Server, Name, Info) ->
     call(SSH, {write_file_info,Server,Name,Info}).
 
 %%%-----------------------------------------------------------------
-%%% @spec read_link(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_link(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 read_link(SSH, Name) ->
     call(SSH, {read_link,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec read_link(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec read_link(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 read_link(SSH, Server, Name) ->
     call(SSH, {read_link,Server,Name}).
 
 %%%-----------------------------------------------------------------
-%%% @spec make_symlink(SSH, Name, Target) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec make_symlink(SSH, Name, Target) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Target :: string(),
+      Reason :: term().
 make_symlink(SSH, Name, Target) ->
     call(SSH, {make_symlink,sftp,Name,Target}).
 %%%-----------------------------------------------------------------
-%%% @spec make_symlink(SSH, Server, Name, Target) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec make_symlink(SSH, Server, Name, Target) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Target :: string(),
+      Reason :: term().
 make_symlink(SSH, Server, Name, Target) ->
     call(SSH, {make_symlink,Server,Name,Target}).
 
 %%%-----------------------------------------------------------------
-%%% @spec rename(SSH, OldName, NewName) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec rename(SSH, OldName, NewName) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      OldName :: string(),
+      NewName :: string(),
+      Reason :: term().
 rename(SSH, OldName, NewName) ->
     call(SSH, {rename,sftp,OldName,NewName}).
 %%%-----------------------------------------------------------------
-%%% @spec rename(SSH, Server, OldName, NewName) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec rename(SSH, Server, OldName, NewName) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      OldName :: string(),
+      NewName :: string(),
+      Reason :: term().
 rename(SSH, Server, OldName, NewName) ->
     call(SSH, {rename,Server,OldName,NewName}).
 
 %%%-----------------------------------------------------------------
-%%% @spec delete(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec delete(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 delete(SSH, Name) ->
     call(SSH, {delete,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec delete(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec delete(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 delete(SSH, Server, Name) ->
     call(SSH, {delete,Server,Name}).
 
 %%%-----------------------------------------------------------------
-%%% @spec make_dir(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec make_dir(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 make_dir(SSH, Name) ->
     call(SSH, {make_dir,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec make_dir(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec make_dir(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 make_dir(SSH, Server, Name) ->
     call(SSH, {make_dir,Server,Name}).
 
 %%%-----------------------------------------------------------------
-%%% @spec del_dir(SSH, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec del_dir(SSH, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Name :: string(),
+      Reason :: term().
 del_dir(SSH, Name) ->
     call(SSH, {del_dir,sftp,Name}).
 %%%-----------------------------------------------------------------
-%%% @spec del_dir(SSH, Server, Name) -> Result
-%%%      SSH = connection()
-%%%      Result = ssh_sftp_return() | {error,Reason}
-%%%      Reason = term()
 %%% @doc For info and other types, see ssh_sftp(3).
+-spec del_dir(SSH, Server, Name) -> ssh_sftp_return() | {error,Reason} when
+      SSH :: connection(),
+      Server :: atom(),
+      Name :: string(),
+      Reason :: term().
 del_dir(SSH, Server, Name) ->
     call(SSH, {del_dir,Server,Name}).
 

--- a/lib/common_test/src/ct_ssh.erl
+++ b/lib/common_test/src/ct_ssh.erl
@@ -294,8 +294,12 @@ session_close(SSH, ChannelId) ->
     call(SSH, {session_close,ChannelId}).
 
 %%%-----------------------------------------------------------------
-%%% @spec exec(SSH,Command) -> {ok,Data} | {error,Reason}
 %%% @equiv exec(SSH,Command,DefaultTimeout)
+-spec exec(SSH, Command) -> {ok,Data} | {error,Reason} when
+      SSH :: connection(),
+      Command :: string(),
+      Data :: list(),
+      Reason :: term().
 exec(SSH, Command) ->
     exec(SSH, undefined, Command, ?DEFAULT_TIMEOUT).
 

--- a/lib/common_test/src/ct_telnet.erl
+++ b/lib/common_test/src/ct_telnet.erl
@@ -190,8 +190,11 @@
 %% @see unix_telnet
 
 %%%-----------------------------------------------------------------
-%%% @spec open(Name) -> {ok,Handle} | {error,Reason}
 %%% @equiv open(Name, telnet)
+-spec open(Name) -> {ok,Handle} | {error,Reason} when
+      Name :: ct:target_name(),
+      Handle :: handle(),
+      Reason :: term().
 open(Name) ->
     open(Name,telnet).
 
@@ -213,9 +216,16 @@ open(Name,ConnType) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec open(KeyOrName, ConnType, TargetMod) ->
-%%%                   {ok,Handle} | {error,Reason}
 %%% @equiv open(KeyOrName, ConnType, TargetMod, [])
+-spec open(KeyOrName, ConnType, TargetMod) ->
+                  {ok,Handle} | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      ConnType :: connection_type(),
+      TargetMod :: atom(),
+      Handle :: handle(),
+      Reason :: term().
 open(KeyOrName,ConnType,TargetMod) ->
     open(KeyOrName,ConnType,TargetMod,KeyOrName).
 
@@ -316,8 +326,12 @@ close(Connection) ->
 %%%=================================================================
 %%% Test suite interface
 %%%-----------------------------------------------------------------
-%%% @spec cmd(Connection, Cmd) -> {ok,Data} | {error,Reason}
 %%% @equiv cmd(Connection, Cmd, [])
+-spec cmd(Connection, Cmd) -> {ok,Data} | {error,Reason} when
+      Connection :: connection(),
+      Cmd :: string(),
+      Data :: [string()],
+      Reason :: term().
 cmd(Connection,Cmd) ->
     cmd(Connection,Cmd,[]).
 %%%-----------------------------------------------------------------
@@ -366,8 +380,13 @@ check_cmd_opts(Opts) ->
     check_send_opts(Opts).
 
 %%%-----------------------------------------------------------------
-%%% @spec cmdf(Connection, CmdFormat, Args) -> {ok,Data} | {error,Reason}
 %%% @equiv cmdf(Connection, CmdFormat, Args, [])
+-spec cmdf(Connection, CmdFormat, Args) -> {ok,Data} | {error,Reason} when
+      Connection :: connection(),
+      CmdFormat :: string(),
+      Args :: list(),
+      Data :: [string()],
+      Reason :: term().
 cmdf(Connection,CmdFormat,Args) ->
     cmdf(Connection,CmdFormat,Args,[]).
 %%%-----------------------------------------------------------------
@@ -412,8 +431,11 @@ get_data(Connection) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec send(Connection, Cmd) -> ok | {error,Reason}
 %%% @equiv send(Connection, Cmd, [])
+-spec send(Connection, Cmd) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Cmd :: string(),
+      Reason :: term().
 send(Connection,Cmd) ->
     send(Connection,Cmd,[]).
 
@@ -457,8 +479,12 @@ check_send_opts([]) ->
 
 
 %%%-----------------------------------------------------------------
-%%% @spec sendf(Connection, CmdFormat, Args) -> ok | {error,Reason}
 %%% @equiv sendf(Connection, CmdFormat, Args, [])
+-spec sendf(Connection, CmdFormat, Args) -> ok | {error,Reason} when
+      Connection :: connection(),
+      CmdFormat :: string(),
+      Args :: list(),
+      Reason :: term().
 sendf(Connection,CmdFormat,Args) when is_list(Args) ->
     sendf(Connection,CmdFormat,Args,[]).
 
@@ -478,8 +504,20 @@ sendf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
     send(Connection,Cmd,Opts).
 
 %%%-----------------------------------------------------------------
-%%% @spec expect(Connection, Patterns) -> term()
 %%% @equiv expect(Connections, Patterns, [])
+-spec expect(Connection, Patterns) -> {ok,Match} |
+                                      {ok,MatchList,HaltReason} |
+                                      {error,Reason} when
+      Connection :: connection(),
+      Patterns :: Pattern | [Pattern],
+      Pattern :: string() | {Tag,string()} | prompt | {prompt,Prompt},
+      Prompt :: string(),
+      Tag :: term(),
+      MatchList :: [Match],
+      Match :: RxMatch | {Tag,RxMatch} | {prompt,Prompt},
+      RxMatch :: [string()],
+      HaltReason :: done | Match,
+      Reason :: timeout | {prompt,Prompt}.
 expect(Connection,Patterns) ->
     expect(Connection,Patterns,[]).
 

--- a/lib/common_test/src/ct_telnet.erl
+++ b/lib/common_test/src/ct_telnet.erl
@@ -127,27 +127,17 @@
 %%
 %% @end
 
-%% @type connection_type() = telnet | ts1 | ts2
-
-%% @type connection() = handle() |
-%% {ct:target_name(),connection_type()} | ct:target_name()
-
-%% @type handle() = ct_gen_conn:handle(). Handle for a
-%% specific telnet connection.
-
-%% @type prompt_regexp() = string(). A regular expression which
-%% matches all possible prompts for a specific type of target. The
-%% regexp must not have any groups i.e. when matching, re:run/3 shall
-%% return a list with one single element.
-%%
-%% @see unix_telnet
-
 -module(ct_telnet).
 
 -export([open/1, open/2, open/3, open/4, close/1]).
 -export([cmd/2, cmd/3, cmdf/3, cmdf/4, get_data/1, 
 	 send/2, send/3, sendf/3, sendf/4,
 	 expect/2, expect/3]).
+
+-export_type([connection/0,
+              connection_type/0,
+              handle/0,
+              prompt_regexp/0]).
 
 %% Callbacks
 -export([init/3,handle_msg/2,reconnect/2,terminate/2]).
@@ -184,20 +174,34 @@
 	       reconns=?RECONNS,
 	       reconn_int=?RECONN_TIMEOUT}).
 
+-type connection_type() :: telnet | ts1 | ts2.
+
+-type connection() :: handle() |
+                      {ct:target_name(), connection_type()} |
+                      ct:target_name().
+
+-type handle() :: ct_gen_conn:handle().
+%% Handle for a specific telnet connection.
+
+-type prompt_regexp() :: string().
+%% A regular expression which matches all possible prompts for a specific
+%% type of target. The regexp must not have any groups i.e. when matching,
+%% re:run/3 shall return a list with one single element.
+%% @see unix_telnet
+
 %%%-----------------------------------------------------------------
 %%% @spec open(Name) -> {ok,Handle} | {error,Reason}
-%%% @equiv open(Name,telnet)
+%%% @equiv open(Name, telnet)
 open(Name) ->
     open(Name,telnet).
 
 %%%-----------------------------------------------------------------
-%%% @spec open(Name,ConnType) -> {ok,Handle} | {error,Reason}
-%%%      Name = target_name()
-%%%      ConnType = ct_telnet:connection_type()
-%%%      Handle = ct_telnet:handle()
-%%%      Reason = term()
-%%%
 %%% @doc Open a telnet connection to the specified target host.
+-spec open(Name, ConnType) -> {ok,Handle} | {error,Reason} when
+      Name :: ct:target_name(),
+      ConnType :: connection_type(),
+      Handle :: handle(),
+      Reason :: term().
 open(Name,ConnType) ->
     case ct_util:get_key_from_name(Name) of
 	{ok, unix} -> % unix host
@@ -209,24 +213,13 @@ open(Name,ConnType) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec open(KeyOrName,ConnType,TargetMod) -> 
-%%%                                     {ok,Handle} | {error,Reason}
-%%% @equiv open(KeyOrName,ConnType,TargetMod,[])
+%%% @spec open(KeyOrName, ConnType, TargetMod) ->
+%%%                   {ok,Handle} | {error,Reason}
+%%% @equiv open(KeyOrName, ConnType, TargetMod, [])
 open(KeyOrName,ConnType,TargetMod) ->
     open(KeyOrName,ConnType,TargetMod,KeyOrName).
 
 %%%-----------------------------------------------------------------
-%%% @spec open(KeyOrName,ConnType,TargetMod,Extra) -> 
-%%%                                     {ok,Handle} | {error,Reason}
-%%%      KeyOrName = Key | Name
-%%%      Key = atom()
-%%%      Name = ct:target_name()
-%%%      ConnType = connection_type()
-%%%      TargetMod = atom()
-%%%      Extra = term()
-%%%      Handle = handle()
-%%%      Reason = term()
-%%%
 %%% @doc Open a telnet connection to the specified target host.
 %%%
 %%% <p>The target data must exist in a configuration file. The connection 
@@ -244,8 +237,18 @@ open(KeyOrName,ConnType,TargetMod) ->
 %%% <p><code>TargetMod</code> is a module which exports the functions
 %%% <code>connect(Ip,Port,KeepAlive,Extra)</code> and <code>get_prompt_regexp()</code>
 %%% for the given <code>TargetType</code> (e.g. <code>unix_telnet</code>).</p>
-%%%
+%%% @end
 %%% @see ct:require/2
+-spec open(KeyOrName, ConnType, TargetMod, Extra) ->
+                  {ok,Handle} | {error,Reason} when
+      KeyOrName :: Key | Name,
+      Key :: atom(),
+      Name :: ct:target_name(),
+      ConnType :: connection_type(),
+      TargetMod :: atom(),
+      Extra :: term(),
+      Handle :: handle(),
+      Reason :: term().
 open(KeyOrName,ConnType,TargetMod,Extra) ->
     case ct:get_config({KeyOrName,ConnType}) of
 	undefined ->
@@ -286,16 +289,16 @@ open(KeyOrName,ConnType,TargetMod,Extra) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec close(Connection) -> ok | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      Reason = term()
-%%%
 %%% @doc Close the telnet connection and stop the process managing it.
 %%% 
 %%% <p>A connection may be associated with a target name and/or a handle.
 %%% If <code>Connection</code> has no associated target name, it may only
 %%% be closed with the handle value (see the <code>open/4</code> 
 %%% function).</p>
+%%% @end
+-spec close(Connection) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Reason :: term().
 close(Connection) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -313,18 +316,11 @@ close(Connection) ->
 %%%=================================================================
 %%% Test suite interface
 %%%-----------------------------------------------------------------
-%%% @spec cmd(Connection,Cmd) -> {ok,Data} | {error,Reason}
-%%% @equiv cmd(Connection,Cmd,[])
+%%% @spec cmd(Connection, Cmd) -> {ok,Data} | {error,Reason}
+%%% @equiv cmd(Connection, Cmd, [])
 cmd(Connection,Cmd) ->
     cmd(Connection,Cmd,[]).
 %%%-----------------------------------------------------------------
-%%% @spec cmd(Connection,Cmd,Opts) -> {ok,Data} | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      Cmd = string()
-%%%      Opts = [Opt]
-%%%      Opt = {timeout,timeout()} | {newline,boolean()}
-%%%      Data = [string()]
-%%%      Reason = term()
 %%% @doc Send a command via telnet and wait for prompt.
 %%%
 %%% <p>This function will by default add a newline to the end of the
@@ -337,6 +333,14 @@ cmd(Connection,Cmd) ->
 %%% prompt. If the time expires, the function returns
 %%% `{error,timeout}'. See the module description for information
 %%% about the default value for the command timeout.</p>
+%%% @end
+-spec cmd(Connection, Cmd, Opts) -> {ok,Data} | {error,Reason} when
+      Connection :: connection(),
+      Cmd :: string(),
+      Opts :: [Opt],
+      Opt :: {timeout,timeout()} | {newline,boolean()},
+      Data :: [string()],
+      Reason :: term().
 cmd(Connection,Cmd,Opts) when is_list(Opts) ->
     case check_cmd_opts(Opts) of
 	ok ->
@@ -362,32 +366,29 @@ check_cmd_opts(Opts) ->
     check_send_opts(Opts).
 
 %%%-----------------------------------------------------------------
-%%% @spec cmdf(Connection,CmdFormat,Args) -> {ok,Data} | {error,Reason}
-%%% @equiv cmdf(Connection,CmdFormat,Args,[])
+%%% @spec cmdf(Connection, CmdFormat, Args) -> {ok,Data} | {error,Reason}
+%%% @equiv cmdf(Connection, CmdFormat, Args, [])
 cmdf(Connection,CmdFormat,Args) ->
     cmdf(Connection,CmdFormat,Args,[]).
 %%%-----------------------------------------------------------------
-%%% @spec cmdf(Connection,CmdFormat,Args,Opts) -> {ok,Data} | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      CmdFormat = string()
-%%%      Args = list()
-%%%      Opts = [Opt]
-%%%      Opt = {timeout,timeout()} | {newline,boolean()}
-%%%      Data = [string()]
-%%%      Reason = term()
 %%% @doc Send a telnet command and wait for prompt 
 %%%      (uses a format string and list of arguments to build the command).
 %%%
 %%% <p>See {@link cmd/3} further description.</p>
+%%% @end
+-spec cmdf(Connection, CmdFormat, Args, Opts) -> {ok,Data} | {error,Reason} when
+      Connection :: connection(),
+      CmdFormat :: string(),
+      Args :: list(),
+      Opts :: [Opt],
+      Opt :: {timeout,timeout()} | {newline,boolean()},
+      Data :: [string()],
+      Reason :: term().
 cmdf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
     Cmd = lists:flatten(io_lib:format(CmdFormat,Args)),
     cmd(Connection,Cmd,Opts).
 
 %%%-----------------------------------------------------------------
-%%% @spec get_data(Connection) -> {ok,Data} | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      Data = [string()]
-%%%      Reason = term()
 %%% @doc Get all data that has been received by the telnet client
 %%% since the last command was sent. Note that only newline terminated
 %%% strings are returned. If the last string received has not yet
@@ -397,6 +398,11 @@ cmdf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
 %%% by default disabled (meaning the function will immediately
 %%% return all complete strings received and save a remaining
 %%% non-terminated string for a later `get_data' call).
+%%% @end
+-spec get_data(Connection) -> {ok,Data} | {error,Reason} when
+      Connection :: connection(),
+      Data :: [string()],
+      Reason :: term().
 get_data(Connection) ->
     case get_handle(Connection) of
 	{ok,Pid} ->
@@ -406,18 +412,12 @@ get_data(Connection) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec send(Connection,Cmd) -> ok | {error,Reason}
-%%% @equiv send(Connection,Cmd,[])
+%%% @spec send(Connection, Cmd) -> ok | {error,Reason}
+%%% @equiv send(Connection, Cmd, [])
 send(Connection,Cmd) ->
     send(Connection,Cmd,[]).
 
 %%%-----------------------------------------------------------------
-%%% @spec send(Connection,Cmd,Opts) -> ok | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      Cmd = string()
-%%%      Opts = [Opt]
-%%%      Opt = {newline,boolean()}
-%%%      Reason = term()
 %%% @doc Send a telnet command and return immediately.
 %%%
 %%% This function will by default add a newline to the end of the
@@ -428,6 +428,13 @@ send(Connection,Cmd) ->
 %%%
 %%% <p>The resulting output from the command can be read with
 %%% <code>get_data/1</code> or <code>expect/2/3</code>.</p>
+%%% @end
+-spec send(Connection, Cmd, Opts) -> ok | {error,Reason} when
+      Connection :: connection(),
+      Cmd :: string(),
+      Opts :: [Opt],
+      Opt :: {newline,boolean()},
+      Reason :: term().
 send(Connection,Cmd,Opts) ->
     case check_send_opts(Opts) of
 	ok ->
@@ -450,55 +457,33 @@ check_send_opts([]) ->
 
 
 %%%-----------------------------------------------------------------
-%%% @spec sendf(Connection,CmdFormat,Args) -> ok | {error,Reason}
-%%% @equiv sendf(Connection,CmdFormat,Args,[])
+%%% @spec sendf(Connection, CmdFormat, Args) -> ok | {error,Reason}
+%%% @equiv sendf(Connection, CmdFormat, Args, [])
 sendf(Connection,CmdFormat,Args) when is_list(Args) ->
     sendf(Connection,CmdFormat,Args,[]).
 
 %%%-----------------------------------------------------------------
-%%% @spec sendf(Connection,CmdFormat,Args,Opts) -> ok | {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      CmdFormat = string()
-%%%      Args = list()
-%%%      Opts = [Opt]
-%%%      Opt = {newline,boolean()}
-%%%      Reason = term()
 %%% @doc Send a telnet command and return immediately (uses a format
 %%% string and a list of arguments to build the command).
+%%% @end
+-spec sendf(Connection, CmdFormat, Args, Opts) -> ok | {error,Reason} when
+      Connection :: connection(),
+      CmdFormat :: string(),
+      Args :: list(),
+      Opts :: [Opt],
+      Opt :: {newline,boolean()},
+      Reason :: term().
 sendf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
     Cmd = lists:flatten(io_lib:format(CmdFormat,Args)),
     send(Connection,Cmd,Opts).
 
 %%%-----------------------------------------------------------------
-%%% @spec expect(Connection,Patterns) -> term()
-%%% @equiv expect(Connections,Patterns,[])
+%%% @spec expect(Connection, Patterns) -> term()
+%%% @equiv expect(Connections, Patterns, [])
 expect(Connection,Patterns) ->
     expect(Connection,Patterns,[]).
 
 %%%-----------------------------------------------------------------
-%%% @spec expect(Connection,Patterns,Opts) -> {ok,Match} | 
-%%%                                           {ok,MatchList,HaltReason} | 
-%%%                                           {error,Reason}
-%%%      Connection = ct_telnet:connection()
-%%%      Patterns = Pattern | [Pattern]
-%%%      Pattern = string() | {Tag,string()} | prompt | {prompt,Prompt}
-%%%      Prompt = string()
-%%%      Tag = term()
-%%%      Opts = [Opt]
-%%%      Opt = {idle_timeout,IdleTimeout} | {total_timeout,TotalTimeout} |
-%%%            repeat | {repeat,N} | sequence | {halt,HaltPatterns} |
-%%%            ignore_prompt | no_prompt_check | wait_for_prompt |
-%%%            {wait_for_prompt,Prompt}
-%%%      IdleTimeout = infinity | integer()
-%%%      TotalTimeout = infinity | integer()
-%%%      N = integer()
-%%%      HaltPatterns = Patterns
-%%%      MatchList = [Match]
-%%%      Match = RxMatch | {Tag,RxMatch} | {prompt,Prompt}
-%%%      RxMatch = [string()]
-%%%      HaltReason = done | Match
-%%%      Reason = timeout | {prompt,Prompt}
-%%%
 %%% @doc Get data from telnet and wait for the expected pattern.
 %%%
 %%% <p><code>Pattern</code> can be a POSIX regular expression. The function
@@ -584,6 +569,29 @@ expect(Connection,Patterns) ->
 %%%
 %%% <p>The <code>repeat</code> and <code>sequence</code> options can be
 %%% combined in order to match a sequence multiple times.</p>
+%%% @end
+-spec expect(Connection, Patterns, Opts) -> {ok,Match} |
+                                            {ok,MatchList,HaltReason} |
+                                            {error,Reason} when
+      Connection :: connection(),
+      Patterns :: Pattern | [Pattern],
+      Pattern :: string() | {Tag,string()} | prompt | {prompt,Prompt},
+      Prompt :: string(),
+      Tag :: term(),
+      Opts :: [Opt],
+      Opt :: {idle_timeout,IdleTimeout} | {total_timeout,TotalTimeout} |
+             repeat | {repeat,N} | sequence | {halt,HaltPatterns} |
+             ignore_prompt | no_prompt_check | wait_for_prompt |
+             {wait_for_prompt,Prompt},
+      IdleTimeout :: infinity | integer(),
+      TotalTimeout :: infinity | integer(),
+      N :: integer(),
+      HaltPatterns :: Patterns,
+      MatchList :: [Match],
+      Match :: RxMatch | {Tag,RxMatch} | {prompt,Prompt},
+      RxMatch :: [string()],
+      HaltReason :: done | Match,
+      Reason :: timeout | {prompt,Prompt}.
 expect(Connection,Patterns,Opts) ->
     case get_handle(Connection) of
 	{ok,Pid} ->

--- a/lib/common_test/src/ct_util.erl
+++ b/lib/common_test/src/ct_util.erl
@@ -80,10 +80,7 @@
 %%%-----------------------------------------------------------------
 start() ->
     start(normal, ".", ?default_verbosity).
-%%% @spec start(Mode) -> Pid | exit(Error)
-%%%       Mode = normal | interactive
-%%%       Pid = pid()
-%%%
+
 %%% @doc Start start the ct_util_server process 
 %%% (tool-internal use only).
 %%%
@@ -94,6 +91,8 @@ start() ->
 %%% <code>ct_util_server</code>.</p>
 %%%
 %%% @see ct
+-spec start(Mode) -> pid() when
+      Mode :: normal | interactive.
 start(LogDir) when is_list(LogDir) ->
     start(normal, LogDir, ?default_verbosity);
 start(Mode) ->
@@ -519,19 +518,17 @@ get_key_from_name(Name)->
     ct_config:get_key_from_name(Name).
 
 %%%-----------------------------------------------------------------
-%%% @spec register_connection(TargetName,Address,Callback,Handle) -> 
-%%%                                              ok | {error,Reason}
-%%%      TargetName = ct:target_name()
-%%%      Address = term()
-%%%      Callback = atom()
-%%%      Handle = term
-%%%
 %%% @doc Register a new connection (tool-internal use only).
 %%%
 %%% <p>This function can be called when a new connection is
 %%% established. The connection data is stored in the connection
 %%% table, and ct_util will close all registered connections when the
 %%% test is finished by calling <code>Callback:close/1</code>.</p>
+-spec register_connection(TargetName, Address, Callback, Handle) -> ok when
+      TargetName :: ct:target_name(),
+      Address :: term(),
+      Callback :: module(),
+      Handle :: term().
 register_connection(TargetName,Address,Callback,Handle) ->
     %% If TargetName is a registered alias for a config
     %% variable, use it as reference for the connection,
@@ -552,28 +549,25 @@ register_connection(TargetName,Address,Callback,Handle) ->
     ok.
 
 %%%-----------------------------------------------------------------
-%%% @spec unregister_connection(Handle) -> ok
-%%%      Handle = term
-%%%
 %%% @doc Unregister a connection (tool-internal use only).
 %%%
 %%% <p>This function should be called when a registered connection is
 %%% closed. It removes the connection data from the connection
 %%% table.</p>
+-spec unregister_connection(Handle) -> ok when
+      Handle :: term().
 unregister_connection(Handle) ->
     ets:delete(?conn_table,Handle),
     ok.
 
 
 %%%-----------------------------------------------------------------
-%%% @spec does_connection_exist(TargetName,Address,Callback) -> 
-%%%                                              {ok,Handle} | false
-%%%      TargetName = ct:target_name()
-%%%      Address = address
-%%%      Callback = atom()
-%%%      Handle = term()
-%%%
 %%% @doc Check if a connection already exists.
+-spec does_connection_exist(TargetName, Address, Callback) -> {ok,Handle} | false when
+      TargetName :: ct:target_name(),
+      Address :: term(),
+      Callback :: module(),
+      Handle :: term().
 does_connection_exist(TargetName,Address,Callback) ->
     case ct_config:get_key_from_name(TargetName) of
 	{ok,_Key} ->
@@ -593,16 +587,15 @@ does_connection_exist(TargetName,Address,Callback) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec get_connection(TargetName,Callback) -> 
-%%%                                {ok,Connection} | {error,Reason}
-%%%      TargetName = ct:target_name()
-%%%      Callback = atom()
-%%%      Connection = {Handle,Address}
-%%%      Handle = term()
-%%%      Address = term()
-%%%
 %%% @doc Return the connection for <code>Callback</code> on the
 %%% given target (<code>TargetName</code>).
+-spec get_connection(TargetName, Callback) -> {ok,Connection} | {error,Reason} when
+      TargetName :: ct:target_name(),
+      Callback :: module(),
+      Connection :: {Handle, Address},
+      Handle :: term(),
+      Address :: term(),
+      Reason :: term().
 get_connection(TargetName,Callback) ->
     %% check that TargetName is a registered alias
     case ct_config:get_key_from_name(TargetName) of
@@ -623,17 +616,17 @@ get_connection(TargetName,Callback) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec get_connections(ConnPid) -> 
-%%%                                {ok,Connections} | {error,Reason}
-%%%      Connections = [Connection]
-%%%      Connection = {TargetName,Handle,Callback,Address}
-%%%      TargetName = ct:target_name() | undefined
-%%%      Handle = term()
-%%%      Callback = atom()
-%%%      Address = term()
-%%%
 %%% @doc Get data for all connections associated with a particular
 %%%      connection pid (see Callback:init/3).
+-spec get_connections(ConnectionPid) -> {ok,Connections} | {error,Reason} when
+      ConnectionPid :: pid(),
+      Connections :: [Connection],
+      Connection :: {TargetName, Handle, Callback, Address},
+      TargetName :: ct:target_name() | undefined,
+      Handle :: term(),
+      Callback :: module(),
+      Address :: term(),
+      Reason :: term().
 get_connections(ConnPid) ->
     Conns = ets:tab2list(?conn_table),
     lists:flatmap(fun(#conn{targetref=TargetName,
@@ -666,17 +659,17 @@ get_target_name(Handle) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec close_connections() -> ok
-%%%
 %%% @doc Close all open connections.
+-spec close_connections() -> ok.
 close_connections() ->
     close_connections(ets:tab2list(?conn_table)),
     ok.
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc 
+-spec override_silence_all_connections() -> Protocols when
+      Protocols :: [Protocol],
+      Protocol :: telnet | ftp | rpc | snmp | ssh.
 override_silence_all_connections() ->
     Protocols = [telnet,ftp,rpc,snmp,ssh],
     override_silence_connections(Protocols),
@@ -737,12 +730,12 @@ reset_silent_connections() ->
     
 
 %%%-----------------------------------------------------------------
-%%% @spec stop(Info) -> ok
-%%%
 %%% @doc Stop the ct_util_server and close all existing connections
 %%% (tool-internal use only).
 %%%
 %%% @see ct
+-spec stop(Info) -> ok when
+      Info :: term().
 stop(Info) ->
     case whereis(ct_util_server) of
 	undefined -> 
@@ -756,20 +749,18 @@ stop(Info) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec update_last_run_index() -> ok
-%%%
 %%% @doc Update <code>ct_run.&lt;timestamp&gt;/index.html</code> 
 %%% (tool-internal use only).
+-spec update_last_run_index() -> ok.
 update_last_run_index() ->
     call(update_last_run_index).
 
 
 %%%-----------------------------------------------------------------
-%%% @spec get_mode() -> Mode
-%%%   Mode = normal | interactive
-%%%
 %%% @doc Return the current mode of the ct_util_server
 %%% (tool-internal use only).
+-spec get_mode() -> Mode when
+      Mode :: normal | interactive.
 get_mode() ->
     call(get_mode).
 
@@ -830,16 +821,13 @@ remove_space([],Acc) ->
 
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc
 is_test_dir(Dir) ->
     lists:last(string:tokens(filename:basename(Dir), "_")) == "test".
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc
+-spec get_testdir(file:name_all(), all) -> file:name_all().
 get_testdir(Dir, all) ->
     Abs = abs_name(Dir),
     case is_test_dir(Abs) of
@@ -883,9 +871,8 @@ get_testdir(Dir, _) ->
     get_testdir(Dir, all).
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc
+-spec get_attached(pid()) -> pid() | undefined.
 get_attached(TCPid) ->
     case dbg_iserver:safe_call({get_attpid,TCPid}) of
 	{ok,AttPid} when is_pid(AttPid) ->
@@ -895,9 +882,8 @@ get_attached(TCPid) ->
     end.
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc
+-spec kill_attached(pid() | undefined, pid() | undefined) -> ok.
 kill_attached(undefined,_AttPid) ->
     ok;
 kill_attached(_TCPid,undefined) ->
@@ -912,9 +898,8 @@ kill_attached(TCPid,AttPid) ->
 	    
 
 %%%-----------------------------------------------------------------
-%%% @spec 
-%%%
 %%% @doc
+-spec warn_duplicates([module()]) -> ok.
 warn_duplicates(Suites) ->
     Warn = 
 	fun(Mod) ->
@@ -928,12 +913,9 @@ warn_duplicates(Suites) ->
 				  "         Use group with sequence property instead.~n",[Mod])
 		end
 	end,
-    lists:foreach(Warn, Suites),
-    ok.
+    lists:foreach(Warn, Suites).
 
 %%%-----------------------------------------------------------------
-%%% @spec
-%%%
 %%% @doc
 get_profile_data() ->
     get_profile_data(all).

--- a/lib/edoc/include/edoc_doclet.hrl
+++ b/lib/edoc/include/edoc_doclet.hrl
@@ -21,38 +21,31 @@
 %% Author contact: carlsson.richard@gmail.com
 %% =====================================================================
 
--define(NO_APP, []).
+-define(NO_APP, "").
 
 %% Context for doclets
 
-%% @type edoc_context() = #context{dir = string(),
-%%                                 env = edoc_lib:edoc_env(),
-%%                                 opts = [term()]}
-
--record(context, {dir = "",
-		  env,
-		  opts = []}).
+-record(context, {dir = "" :: string(),
+		  env :: edoc_lib:edoc_env(),
+		  opts = [] :: [term()]
+                 }).
+-type edoc_context() :: #context{}.
 
 %% Doclet commands
 
-%% @type no_app().
-%%    A value used to mark absence of an Erlang application
-%%    context. Use the macro `NO_APP' defined in
-%%    <a href="../include/edoc_doclet.hrl">`edoc_doclet.hrl'</a>
-%%    to produce this value.
+-type no_app() :: string().
+%% A value used to mark absence of an Erlang application
+%% context. Use the macro `NO_APP' defined in
+%% <a href="../include/edoc_doclet.hrl">`edoc_doclet.hrl'</a>
+%% to produce this value.
 
-%% @type doclet_gen() = #doclet_gen{sources = [string()],
-%%                                  app = no_app() | atom(),
-%%                                  modules = [atom()]}
-
--record(doclet_gen, {sources = [],
-		     app = ?NO_APP,
-		     modules = []
+-record(doclet_gen, {sources = [] :: [string()],
+		     app = ?NO_APP :: no_app() | atom(),
+		     modules = [] :: [atom()]
 		    }).
+-type doclet_gen() :: #doclet_gen{}.
 
-%% @type doclet_toc() = #doclet_gen{paths = [string()],
-%%                                  indir = string()}
-
--record(doclet_toc, {paths,
-		     indir
+-record(doclet_toc, {paths :: [string()],
+		     indir :: string()
 		    }).
+-type doclet_toc() :: #doclet_toc{}.

--- a/lib/edoc/src/edoc.erl
+++ b/lib/edoc/src/edoc.erl
@@ -55,10 +55,16 @@
 	 read_comments/1, read_comments/2,
 	 read_source/1, read_source/2]).
 
+-export_type([module/0]).
+
 -compile({no_auto_import,[error/1]}).
 
 -include("edoc.hrl").
 
+
+-opaque edoc_module() :: term().
+-type filename() :: file:filename().
+-type proplist() :: [term()].
 
 %% @spec (Name::filename()) -> ok
 %% @equiv file(Name, [])
@@ -68,10 +74,7 @@ file(Name) ->
     file(Name, []).
 
 %% @spec file(filename(), proplist()) -> ok
-%%
-%% @type filename() = //kernel/file:filename()
-%% @type proplist() = [term()]
-%%
+
 %% @deprecated This is part of the old interface to EDoc and is mainly
 %% kept for backwards compatibility. The preferred way of generating
 %% documentation is through one of the functions {@link application/2}
@@ -125,30 +128,38 @@ file(Name, Options) ->
 
 %% TODO: better documentation of files/1/2, application/1/2/3
 
-%% @spec (Files::[filename()]) -> ok
+-spec files(Files) -> ok when
+      Files :: [filename()].
 
 files(Files) ->
     files(Files, []).
 
-%% @spec (Files::[filename()],
-%%        Options::proplist()) -> ok
 %% @doc Runs EDoc on a given set of source files. See {@link run/2} for
 %% details, including options.
 %% @equiv run([], Files, Options)
 
+-spec files(Files, Options) -> ok when
+      Files :: [filename()],
+      Options :: proplist().
+
 files(Files, Options) ->
     run(Files, Options).
 
-%% @spec (Application::atom()) -> ok
 %% @equiv application(Application, [])
+
+-spec application(Application) -> ok when
+      Application :: atom().
 
 application(App) ->
     application(App, []).
 
-%% @spec (Application::atom(), Options::proplist()) -> ok
 %% @doc Run EDoc on an application in its default app-directory. See
 %% {@link application/3} for details.
 %% @see application/1
+
+-spec application(Application, Options) -> ok when
+      Application :: atom(),
+      Options :: proplist().
 
 application(App, Options) when is_atom(App) ->
     case code:lib_dir(App) of
@@ -160,8 +171,6 @@ application(App, Options) when is_atom(App) ->
  	    exit(error)
     end.
 
-%% @spec (Application::atom(), Dir::filename(), Options::proplist())
-%%        -> ok
 %% @doc Run EDoc on an application located in the specified directory.
 %% Tries to automatically set up good defaults. Unless the user
 %% specifies otherwise:
@@ -185,6 +194,11 @@ application(App, Options) when is_atom(App) ->
 %% See {@link run/2} for details, including options.
 %%
 %% @see application/2
+
+-spec application(Application, Dir, Options) -> ok when
+      Application :: atom(),
+      Dir :: filename(),
+      Options :: proplist().
 
 application(App, Dir, Options) when is_atom(App) ->
     Src = edoc_lib:try_subdir(Dir, ?SOURCE_DIR),
@@ -227,8 +241,6 @@ opt_negations() ->
      {no_subpackages, subpackages},
      {no_report_missing_types, report_missing_types}].
 
-%% @spec run(Files::[filename()],
-%%           Options::proplist()) -> ok
 %% @doc Runs EDoc on a given set of source files. Note
 %% that the doclet plugin module has its own particular options; see the
 %% `doclet' option below.
@@ -314,6 +326,10 @@ opt_negations() ->
 %% INHERIT-OPTIONS: edoc_lib:find_sources/2
 %% INHERIT-OPTIONS: edoc_lib:run_doclet/2
 %% INHERIT-OPTIONS: edoc_lib:get_doc_env/3
+
+-spec run(Files, Options) -> ok when
+      Files :: [filename()],
+      Options :: proplist().
 
 run(Files, Opts0) ->
     Opts = expand_opts(Opts0),
@@ -434,14 +450,14 @@ toc(Dir, Paths, Opts0) ->
     edoc_lib:run_doclet(F, Opts).
 
 
-%% @spec read(File::filename()) -> string()
 %% @equiv read(File, [])
+
+-spec read(File) -> string() when
+      File :: filename().
 
 read(File) ->
     read(File, []).
 
-%% @spec read(File::filename(), Options::proplist()) -> string()
-%%
 %% @doc Reads and processes a source file and returns the resulting
 %% EDoc-text as a string. See {@link get_doc/2} and {@link layout/2} for
 %% options.
@@ -450,19 +466,23 @@ read(File) ->
 
 %% INHERIT-OPTIONS: get_doc/2, layout/2
 
+-spec read(File, Options) -> string() when
+      File :: filename(),
+      Options :: proplist().
+
 read(File, Opts) ->
     {_ModuleName, Doc} = get_doc(File, Opts),
     layout(Doc, Opts).
 
 
-%% @spec layout(Doc::edoc_module()) -> string()
 %% @equiv layout(Doc, [])
+
+-spec layout(Doc) -> string() when
+      Doc :: edoc_module().
 
 layout(Doc) ->
     layout(Doc, []).
 
-%% @spec layout(Doc::edoc_module(), Options::proplist()) -> string()
-%%
 %% @doc Transforms EDoc module documentation data to text. The default
 %% layout creates an HTML document.
 %%
@@ -484,6 +504,10 @@ layout(Doc) ->
 
 %% INHERIT-OPTIONS: edoc_lib:run_layout/2
 
+-spec layout(Doc, Options) -> string() when
+      Doc :: edoc_module(),
+      Options :: proplist().
+
 layout(Doc, Opts) ->
     F = fun (M) ->
 		M:module(Doc, Opts)
@@ -491,40 +515,45 @@ layout(Doc, Opts) ->
     edoc_lib:run_layout(F, Opts).
 
 
-%% @spec (File) ->  [comment()]
-%% @type comment() = {Line, Column, Indentation, Text}
-%% where
-%%   Line = integer(),
-%%   Column = integer(),
-%%   Indentation = integer(),
-%%   Text = [string()]
+-type comment() :: {Line :: integer(),
+                    Column :: integer(),
+                    Indentation :: integer(),
+                    Text :: [string()]}.
+
 %% @equiv read_comments(File, [])
+
+-spec read_comments(File) -> [comment()] when
+      File :: filename().
 
 read_comments(File) ->
     read_comments(File, []).
 
-%% @spec read_comments(File::filename(), Options::proplist()) ->
-%%           [comment()]
-%%
 %% @doc Extracts comments from an Erlang source code file. See the
 %% module {@link //syntax_tools/erl_comment_scan} for details on the
 %% representation of comments. Currently, no options are avaliable.
+
+-spec read_comments(File, Options) -> [comment()] when
+      File :: filename(),
+      Options :: proplist().
 
 read_comments(File, _Opts) ->
     erl_comment_scan:file(File).
 
 
-%% @spec (File) -> [syntaxTree()]
 %% @equiv read_source(File, [])
+
+-spec read_source(File) -> [syntaxTree()] when
+      File :: filename().
 
 read_source(Name) ->
     read_source(Name, []).
 
-%% @spec read_source(File::filename(), Options::proplist()) ->
-%%           [syntaxTree()]
-%%
-%% @type syntaxTree() = //syntax_tools/erl_syntax:syntaxTree()
-%%
+-spec read_source(File, Options) -> [syntaxTree()] when
+      File :: filename(),
+      Options :: proplist().
+
+-type syntaxTree() :: erl_syntax:syntaxTree().
+
 %% @doc Reads an Erlang source file and returns the list of "source code
 %% form" syntax trees.
 %%
@@ -719,20 +748,19 @@ check_forms(Fs, Name) ->
     lists:foreach(Fun, Fs).
 
 
-%% @spec get_doc(File::filename()) -> {ModuleName, edoc_module()}
+%% The EDoc documentation data for a module,
+%% expressed as an XML document in {@link //xmerl. XMerL} format. See
+%% the file <a href="../priv/edoc.dtd">`edoc.dtd'</a> for details.
+
 %% @equiv get_doc(File, [])
+
+-spec get_doc(File) -> {ModuleName, edoc_module()} when
+      File :: filename(),
+      ModuleName :: atom().
 
 get_doc(File) ->
     get_doc(File, []).
 
-%% @spec get_doc(File::filename(), Options::proplist()) ->
-%%           {ModuleName, edoc_module()}
-%%	ModuleName = atom()
-%%
-%% @type edoc_module(). The EDoc documentation data for a module,
-%% expressed as an XML document in {@link //xmerl. XMerL} format. See
-%% the file <a href="../priv/edoc.dtd">`edoc.dtd'</a> for details.
-%%
 %% @doc Reads a source code file and extracts EDoc documentation data.
 %% Note that without an environment parameter (see {@link get_doc/3}),
 %% hypertext links may not be correct.
@@ -779,20 +807,27 @@ get_doc(File) ->
 %% INHERIT-OPTIONS: get_doc/3
 %% INHERIT-OPTIONS: edoc_lib:get_doc_env/3
 
+-spec get_doc(File, Options) -> {ModuleName, edoc_module()} when
+      File :: filename(),
+      Options :: proplist(),
+      ModuleName :: atom().
+
 get_doc(File, Opts) ->
     Env = edoc_lib:get_doc_env(Opts),
     get_doc(File, Env, Opts).
 
-%% @spec get_doc(File::filename(), Env::edoc_lib:edoc_env(),
-%%        Options::proplist()) -> {ModuleName, edoc_module()}
-%%     ModuleName = atom()
-%%
 %% @doc Like {@link get_doc/2}, but for a given environment
 %% parameter. `Env' is an environment created by {@link
 %% edoc_lib:get_doc_env/3}.
 
 %% INHERIT-OPTIONS: read_source/2, read_comments/2, edoc_extract:source/5
 %% DEFER-OPTIONS: get_doc/2
+
+-spec get_doc(File, Env, Options) -> {ModuleName, edoc_module()} when
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      ModuleName :: atom().
 
 get_doc(File, Env, Opts) ->
     edoc_extract:source(File, Env, Opts).

--- a/lib/edoc/src/edoc.erl
+++ b/lib/edoc/src/edoc.erl
@@ -55,25 +55,30 @@
 	 read_comments/1, read_comments/2,
 	 read_source/1, read_source/2]).
 
--export_type([module/0]).
+-export_type([edoc_module/0]).
 
 -compile({no_auto_import,[error/1]}).
 
 -include("edoc.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
 
 
--opaque edoc_module() :: term().
+%% The EDoc documentation data for a module,
+%% expressed as an XML document in {@link //xmerl. XMerL} format. See
+%% the file <a href="../priv/edoc.dtd">`edoc.dtd'</a> for details.
+-opaque edoc_module() :: #xmlElement{}.
+
 -type filename() :: file:filename().
 -type proplist() :: [term()].
 
-%% @spec (Name::filename()) -> ok
 %% @equiv file(Name, [])
 %% @deprecated See {@link file/2} for details.
 
+-spec file(Name) -> ok when
+      Name :: filename().
+
 file(Name) ->
     file(Name, []).
-
-%% @spec file(filename(), proplist()) -> ok
 
 %% @deprecated This is part of the old interface to EDoc and is mainly
 %% kept for backwards compatibility. The preferred way of generating
@@ -113,6 +118,10 @@ file(Name) ->
 
 %% NEW-OPTIONS: source_suffix, file_suffix, dir
 %% INHERIT-OPTIONS: read/2
+
+-spec file(Name, Options) -> ok when
+      Name :: filename(),
+      Options :: proplist().
 
 file(Name, Options) ->
     Text = read(Name, Options),
@@ -747,10 +756,6 @@ check_forms(Fs, Name) ->
 	  end,
     lists:foreach(Fun, Fs).
 
-
-%% The EDoc documentation data for a module,
-%% expressed as an XML document in {@link //xmerl. XMerL} format. See
-%% the file <a href="../priv/edoc.dtd">`edoc.dtd'</a> for details.
 
 %% @equiv get_doc(File, [])
 

--- a/lib/edoc/src/edoc_extract.erl
+++ b/lib/edoc/src/edoc_extract.erl
@@ -32,15 +32,10 @@
 %% %% @headerfile "edoc.hrl" (disabled until it can be made private)
 -include("edoc.hrl").
 
-%% @type filename() = file:filename().
-%% @type proplist() = proplists:property().
-%% @type syntaxTree() = erl_syntax:syntaxTree().
+-type filename() :: file:filename().
+-type proplist() :: proplists:property().
+-type syntaxTree() :: erl_syntax:syntaxTree().
 
-%% @spec source(File::filename(), Env::edoc_env(), Options::proplist())
-%%             -> {ModuleName, edoc:edoc_module()}
-%%    ModuleName = atom()
-%%    proplist() = [term()]
-%%
 %% @doc Like {@link source/5}, but reads the syntax tree and the
 %% comments from the specified file.
 %%
@@ -48,18 +43,17 @@
 %% @see edoc:read_source/2
 %% @see source/4
 
+-spec source(File, Env, Options) -> {ModuleName, edoc:edoc_module()} when
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: [term()],
+      ModuleName :: atom().
+
 source(File, Env, Opts) ->
     Forms = edoc:read_source(File, Opts),
     Comments = edoc:read_comments(File, Opts),
     source(Forms, Comments, File, Env, Opts).
 
-%% @spec source(Forms, Comments::[edoc:comment()], File::filename(),
-%%              Env::edoc_env(), Options::proplist()) ->
-%%           {ModuleName, edoc:edoc_module()}
-%%
-%%    Forms = syntaxTree() | [syntaxTree()]
-%%    ModuleName = atom()
-%%
 %% @doc Like {@link source/4}, but first inserts the given comments in
 %% the syntax trees. The syntax trees must contain valid position
 %% information. (Cf. {@link edoc:read_comments/2}.)
@@ -70,6 +64,14 @@ source(File, Env, Opts) ->
 %% @see source/4
 %% @see //syntax_tools/erl_recomment
 
+-spec source(Forms, Comments, File, Env, Options) -> {ModuleName, edoc:edoc_module()} when
+      Forms :: syntaxTree() | [syntaxTree()],
+      Comments :: [edoc:comment()],
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      ModuleName :: atom().
+
 source(Forms, Comments, File, Env, Opts) when is_list(Forms) ->
     Forms1 = erl_syntax:form_list(Forms),
     source(Forms1, Comments, File, Env, Opts);
@@ -78,14 +80,6 @@ source(Forms, Comments, File, Env, Opts) ->
     TypeDocs = find_type_docs(Forms, Comments, Env, File),
     source1(Tree, File, Env, Opts, TypeDocs).
 
-%% @spec source(Forms, File::filename(), Env::edoc_env(),
-%%              Options::proplist()) ->
-%%           {ModuleName, edoc:edoc_module()}
-%%
-%%	    Forms = syntaxTree() | [syntaxTree()]
-%%	    ModuleName = atom()
-%% @type edoc_env() = edoc_lib:edoc_env()
-%%
 %% @doc Extracts EDoc documentation from commented source code syntax
 %% trees. The given `Forms' must be a single syntax tree of
 %% type `form_list', or a list of syntax trees representing
@@ -107,6 +101,13 @@ source(Forms, Comments, File, Env, Opts) ->
 
 %% INHERIT-OPTIONS: add_macro_defs/3
 %% INHERIT-OPTIONS: edoc_data:module/4
+
+-spec source(Forms, File, Env, Options) -> {ModuleName, edoc:edoc_module()} when
+      Forms :: syntaxTree() | [syntaxTree()],
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      ModuleName :: atom().
 
 source(Forms, File, Env, Opts) when is_list(Forms) ->
     source(erl_syntax:form_list(Forms), File, Env, Opts);
@@ -130,11 +131,6 @@ source1(Tree, File0, Env, Opts, TypeDocs) ->
     Data = edoc_data:module(Module, Entries2, Env2, Opts),
     {Name, Data}.
 
-%% @spec header(File::filename(), Env::edoc_env(), Options::proplist())
-%%             -> {ok, Tags} | {error, Reason}
-%%   Tags = [term()]
-%%   Reason = term()
-%%
 %% @doc Similar to {@link header/5}, but reads the syntax tree and the
 %% comments from the specified file.
 %%
@@ -142,18 +138,18 @@ source1(Tree, File0, Env, Opts, TypeDocs) ->
 %% @see edoc:read_source/2
 %% @see header/4
 
+-spec header(File, Env, Options) -> {ok, Tags} | {error, Reason} when
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      Tags :: [term()],
+      Reason :: term().
+
 header(File, Env, Opts) ->
     Forms = edoc:read_source(File),
     Comments = edoc:read_comments(File),
     header(Forms, Comments, File, Env, Opts).
 
-%% @spec header(Forms, Comments::[edoc:comment()], File::filename(),
-%%              Env::edoc_env(), Options::proplist()) ->
-%%       {ok, Tags} | {error, Reason}
-%%   Forms = syntaxTree() | [syntaxTree()]
-%%   Tags = [term()]
-%%   Reason = term()
-%%
 %% @doc Similar to {@link header/4}, but first inserts the given
 %% comments in the syntax trees. The syntax trees must contain valid
 %% position information. (Cf. {@link edoc:read_comments/2}.)
@@ -162,6 +158,15 @@ header(File, Env, Opts) ->
 %% @see header/4
 %% @see //syntax_tools/erl_recomment
 
+-spec header(Forms, Comments, File, Env, Options) -> {ok, Tags} | {error, Reason} when
+      Forms :: syntaxTree() | [syntaxTree()],
+      Comments :: [edoc:comment()],
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      Tags :: [term()],
+      Reason :: term().
+
 header(Forms, Comments, File, Env, Opts) when is_list(Forms) ->
     Forms1 = erl_syntax:form_list(Forms),
     header(Forms1, Comments, File, Env, Opts);
@@ -169,13 +174,6 @@ header(Forms, Comments, File, Env, Opts) ->
     Tree = erl_recomment:quick_recomment_forms(Forms, Comments),
     header(Tree, File, Env, Opts).
 
-%% @spec header(Forms, File::filename(), Env::edoc_env(),
-%%              Options::proplist()) ->
-%%       {ok, Tags} | {error, Reason}
-%%   Forms = syntaxTree() | [syntaxTree()]
-%%   Tags = [term()]
-%%   Reason = term()
-%%
 %% @doc Extracts EDoc documentation from commented header file syntax
 %% trees. Similar to {@link source/5}, but ignores any documentation
 %% that occurs before a module declaration or a function definition.
@@ -184,6 +182,14 @@ header(Forms, Comments, File, Env, Opts) ->
 %%
 %% @see header/5
 %% @see //syntax_tools/erl_recomment
+
+-spec header(Forms, File, Env, Options) -> {ok, Tags} | {error, Reason} when
+      Forms :: syntaxTree() | [syntaxTree()],
+      File :: filename(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      Tags :: [term()],
+      Reason :: term().
 
 header(Forms, File, Env, Opts) when is_list(Forms) ->
     header(erl_syntax:form_list(Forms), File, Env, Opts);
@@ -214,12 +220,6 @@ add_macro_defs(Defs0, Opts, Env) ->
     edoc_macros:check_defs(Defs),
     Env#env{macros = Defs ++ Defs0 ++ Env#env.macros}.
 
-%% @spec file(File::filename(), Context, Env::edoc_env(),
-%%            Options::proplist()) -> {ok, Tags} | {error, Reason}
-%%   Context = overview
-%%   Tags = [term()]
-%%   Reason = term()
-%%
 %% @doc Reads a text file and returns the list of tags in the file. Any
 %% lines of text before the first tag are ignored. `Env' is an
 %% environment created by {@link edoc_lib:get_doc_env/3}. Upon error,
@@ -229,6 +229,14 @@ add_macro_defs(Defs0, Opts, Env) ->
 %% See {@link text/4} for options.
 
 %% INHERIT-OPTIONS: text/4
+
+-spec file(File, Context, Env, Options) -> {ok, Tags} | {error, Reason} when
+      File :: filename(),
+      Context :: overview,
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      Tags :: [term()],
+      Reason :: term().
 
 file(File, Context, Env, Opts) ->
     case file:read_file(File) of
@@ -245,11 +253,6 @@ file(File, Context, Env, Opts) ->
     end.
 
 
-%% @spec (Text::string(), Context, Env::edoc_env(),
-%%        Options::proplist()) -> Tags
-%%     Context = overview
-%%     Tags = [term()]
-%%
 %% @doc Returns the list of tags in the text. Any lines of text before
 %% the first tag are ignored. `Env' is an environment created by {@link
 %% edoc_lib:get_doc_env/3}.
@@ -258,6 +261,13 @@ file(File, Context, Env, Opts) ->
 
 %% INHERIT-OPTIONS: add_macro_defs/3
 %% DEFER-OPTIONS: source/4
+
+-spec text(Text, Context, Env, Options) -> Tags when
+      Text :: string(),
+      Context :: overview | atom(),
+      Env :: edoc_lib:edoc_env(),
+      Options :: proplist(),
+      Tags :: [term()].
 
 text(Text, Context, Env, Opts) ->
     text(Text, Context, Env, Opts, "").
@@ -280,10 +290,13 @@ text(Text, Context, Env, Opts, Where) ->
     end.
 
 
-%% @spec (Forms::[syntaxTree()], File::filename()) -> module()
 %% @doc Initialises a module-info record with data about the module
 %% represented by the list of forms. Exports are guaranteed to exist in
 %% the set of defined names.
+
+-spec get_module_info(Forms, File) -> module() when
+      Forms :: [syntaxTree()],
+      File :: filename().
 
 get_module_info(Forms, File) ->
     L = case catch {ok, erl_syntax_lib:analyze_forms(Forms)} of
@@ -327,9 +340,12 @@ get_list_keyval(Key, L) ->
 	    []
     end.
 
-%% @spec (Forms::[syntaxTree()]) -> [syntaxTree()]
 %% @doc Preprocessing: copies any precomments on forms to standalone
 %% comments, and removes "invisible" forms from the list.
+
+-spec preprocess_forms(Forms) -> Preprocessed when
+      Forms :: [syntaxTree()],
+      Preprocessed :: [syntaxTree()].
 
 preprocess_forms(Tree) ->
     preprocess_forms_1(erl_syntax:form_list_elements(
@@ -432,11 +448,11 @@ comment_text([C | Cs], Ss) ->
 comment_text([], Ss) ->
     Ss.
 
-%% @spec (string()) -> string()
-%%
 %% @doc Replaces leading `%' characters by spaces. For example, `"%%%
 %% foo" -> "\s\s\s foo"', but `"% % foo" -> "\s % foo"', since the
 %% second `%' is preceded by whitespace.
+
+-spec remove_percent_chars(string()) -> string().
 
 remove_percent_chars([$% | Cs]) -> [$\s | remove_percent_chars(Cs)];
 remove_percent_chars(Cs) -> Cs.

--- a/lib/edoc/src/edoc_lib.erl
+++ b/lib/edoc/src/edoc_lib.erl
@@ -672,12 +672,14 @@ try_subdir(Dir, Subdir) ->
 	false -> Dir
     end.
 
-%% @spec (Text::deep_string(), Dir::filename(),
-%%        Name::filename()) -> ok
-%%
 %% @doc Write the given `Text' to the file named by `Name' in directory
 %% `Dir'. If the target directory does not exist, it will be created.
 %% @private
+
+-spec write_file(Text, Dir, Name) -> ok when
+      Text :: iolist(),
+      Dir :: filename(),
+      Name :: filename().
 
 write_file(Text, Dir, Name) ->
     write_file(Text, Dir, Name, [{encoding,latin1}]).
@@ -926,9 +928,11 @@ add_new(K, V, D) ->
 	    dict:store(K, V, D)
     end.
 
-%% @spec (Options::proplist()) -> edoc_env()
 %% @equiv get_doc_env([], [], Opts)
 %% @private
+
+-spec get_doc_env(Options) -> edoc_env() when
+      Options :: proplist().
 
 get_doc_env(Opts) ->
     get_doc_env([], [], Opts).

--- a/lib/percept/src/egd.erl
+++ b/lib/percept/src/egd.erl
@@ -42,16 +42,11 @@
 %%
 %%==========================================================================
 
-%% @type egd_image()
-%% @type font()
-%% @type point() = {integer(), integer()}
-%% @type color()  
-%% @type render_option() = {render_engine, opaque} | {render_engine, alpha}
-
 -type egd_image() :: pid().
 -type point() :: {non_neg_integer(), non_neg_integer()}.
 -type render_option() :: {'render_engine', 'opaque'} | {'render_engine', 'alpha'}.
 -type color() :: {float(), float(), float(), float()}.
+-type font() :: egd_font:font().
 
 %%==========================================================================
 %%

--- a/lib/percept/src/egd.erl
+++ b/lib/percept/src/egd.erl
@@ -54,26 +54,26 @@
 %%
 %%==========================================================================
 
-%% @spec create(integer(), integer()) -> egd_image()
 %% @doc Creates an image area and returns its reference.
 
--spec create(Width :: integer(), Height :: integer()) -> egd_image().
+-spec create(Width, Height) -> egd_image() when
+      Width :: integer(),
+      Height :: integer().
 
 create(Width,Height) ->
     spawn_link(fun() -> init(trunc(Width),trunc(Height)) end).
 
 
-%% @spec destroy(egd_image()) -> ok
 %% @doc Destroys the image.
 
--spec destroy(Image :: egd_image()) -> ok.
+-spec destroy(Image) -> ok when
+      Image :: egd_image().
 
 destroy(Image) ->
    cast(Image, destroy),
    ok.
 
 
-%% @spec render(egd_image()) -> binary()
 %% @equiv render(Image, png, [{render_engine, opaque}])
 
 -spec render(Image :: egd_image()) -> binary().
@@ -81,130 +81,181 @@ destroy(Image) ->
 render(Image) ->
     render(Image, png, [{render_engine, opaque}]).
 
-%% @spec render(egd_image(), png | raw_bitmap) -> binary() 
 %% @equiv render(Image, Type, [{render_engine, opaque}])
+
+-spec render(Image, Type) -> binary() when
+      Image :: egd_image(),
+      Type :: png | raw_bitmap.
 
 render(Image, Type) ->
     render(Image, Type, [{render_engine, opaque}]).
 
-%% @spec render(egd_image(), png | raw_bitmap, [render_option()]) -> binary() 
 %% @doc Renders a binary from the primitives specified by egd_image(). The
 %% 	binary can either be a raw bitmap with rgb tripplets or a binary in png
 %%	format.
+%% @end
 
--spec render(
-	Image :: egd_image(), 
-	Type :: 'png' | 'raw_bitmap' | 'eps',
-	Options :: [render_option()]) -> binary().
+-spec render(Image, Type, Options) -> binary() when
+      Image :: egd_image(),
+      Type :: 'png' | 'raw_bitmap' | 'eps',
+      Options :: [render_option()].
 
 render(Image, Type, Options) ->
     {render_engine, RenderType} = proplists:lookup(render_engine, Options),
     call(Image, {render, Type, RenderType}).
 
 
-%% @spec information(egd_image()) -> ok
 %% @hidden
 %% @doc Writes out information about the image. This is a debug feature
 %%	mainly.
+%% @end
+
+-spec information(Image) -> ok when
+      Image :: egd_image().
 
 information(Pid) ->
     cast(Pid, information),
     ok.
 
-%% @spec line(egd_image(), point(), point(), color()) -> ok
 %% @doc Creates a line object from P1 to P2 in the image.
 
--spec line(
-	Image :: egd_image(),
-	P1 :: point(),
-	P2 :: point(),
-	Color :: color()) -> 'ok'.
+-spec line(Image, Point1, Point2, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Color :: color().
 
 line(Image, P1, P2, Color) ->
     cast(Image, {line, P1, P2, Color}),
     ok.
 
-%% @spec color( Value | Name ) -> color()
-%% where
-%%  Value = {byte(), byte(), byte()} | {byte(), byte(), byte(), byte()} 
-%%  Name  = black | silver | gray | white | maroon | red | purple | fuchia | green | lime | olive | yellow | navy | blue | teal | aqua
 %% @doc Creates a color reference.
 
--spec color(Value :: {byte(), byte(), byte()} | {byte(), byte(), byte(), byte()} | atom()) ->
-    color().
+-spec color(ValueOrName) -> color() when
+      ValueOrName :: Value | Name,
+      Value :: {byte(), byte(), byte()} | {byte(), byte(), byte(), byte()},
+      Name :: black | silver | gray | white | maroon | red | purple | fuchia | green | lime | olive | yellow | navy | blue | teal | aqua.
 
 color(Color) ->
     egd_primitives:color(Color).
 
-%% @spec color(egd_image(), {byte(), byte(), byte()}) -> color()
 %% @doc Creates a color reference.
 %% @hidden
+
+-spec color(_Image, Color) -> color() when
+      _Image :: egd_image(),
+      Color :: {byte(), byte(), byte()}.
 
 color(_Image, Color) ->
     egd_primitives:color(Color).
 
-%% @spec text(egd_image(), point(), font(), string(), color()) -> ok
 %% @doc Creates a text object.
+
+-spec text(Image, Point, Font, Text, Color) -> ok when
+      Image :: egd_image(),
+      Point :: point(),
+      Font :: font(),
+      Text :: string(),
+      Color :: color().
 
 text(Image, P, Font, Text, Color) ->
     cast(Image, {text, P, Font, Text, Color}),
     ok.
 
-%% @spec rectangle(egd_image(), point(), point(), color()) -> ok
 %% @doc Creates a rectangle object.
+
+-spec rectangle(Image, Point1, Point2, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Color :: color().
 
 rectangle(Image, P1, P2, Color) ->
     cast(Image, {rectangle, P1, P2, Color}),
     ok.
 
-%% @spec filledRectangle(egd_image(), point(), point(), color()) -> ok
 %% @doc Creates a filled rectangle object.
+
+-spec filledRectangle(Image, Point1, Point2, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Color :: color().
 
 filledRectangle(Image, P1, P2, Color) ->
     cast(Image, {filled_rectangle, P1, P2, Color}),
     ok.
 
-%% @spec filledEllipse(egd_image(), point(), point(), color()) -> ok
 %% @doc Creates a filled ellipse object.
+
+-spec filledEllipse(Image, Point1, Point2, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Color :: color().
 
 filledEllipse(Image, P1, P2, Color) ->
     cast(Image, {filled_ellipse, P1, P2, Color}),
     ok.
 
-%% @spec filledTriangle(egd_image(), point(), point(), point(), color()) -> ok
 %% @hidden
 %% @doc Creates a filled triangle object.
+
+-spec filledTriangle(Image, Point1, Point2, Point3, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Point3 :: point(),
+      Color :: color().
 
 filledTriangle(Image, P1, P2, P3, Color) ->
     cast(Image, {filled_triangle, P1, P2, P3, Color}),
     ok.
 
-%% @spec polygon(egd_image(), [point()], color()) -> ok
 %% @hidden
 %% @doc Creates a filled filled polygon object.
+
+-spec polygon(Image, Points, Color) -> ok when
+      Image :: egd_image(),
+      Points :: [point()],
+      Color :: color().
 
 polygon(Image, Pts, Color) ->
     cast(Image, {polygon, Pts, Color}),
     ok.
 
-%% @spec arc(egd_image(), point(), point(), color()) -> ok
 %% @hidden
 %% @doc Creates an arc with radius of bbx corner.
+
+-spec arc(Image, Point1, Point2, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      Color :: color().
 
 arc(Image, P1, P2, Color) ->
     cast(Image, {arc, P1, P2, Color}),
     ok.
 
-%% @spec arc(egd_image(), point(), point(), integer(), color()) -> ok
 %% @hidden
 %% @doc Creates an arc.
+
+-spec arc(Image, Point1, Point2, D, Color) -> ok when
+      Image :: egd_image(),
+      Point1 :: point(),
+      Point2 :: point(),
+      D :: integer(),
+      Color :: color().
 
 arc(Image, P1, P2, D, Color) ->
     cast(Image, {arc, P1, P2, D, Color}),
     ok.
 
-%% @spec save(binary(), string()) -> ok
-%% @doc Saves the binary to file. 
+%% @doc Saves the binary to file.
+
+-spec save(Binary, Filename) -> ok when
+      Binary :: binary(),
+      Filename :: string().
 
 save(Binary, Filename) when is_binary(Binary) ->
     file:write_file(Filename, Binary),

--- a/lib/percept/src/egd_font.erl
+++ b/lib/percept/src/egd_font.erl
@@ -24,6 +24,10 @@
 -module(egd_font).
 
 -export([load/1, size/1, glyph/2]).
+
+-type font() :: {Name::atom(), information}.
+-export_type([font/0]).
+
 -include("egd.hrl").
 
 %% Font represenatation in ets table

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -23,9 +23,6 @@
 %%
 %% This module contains utility functions for working with the
 %% abstract data type defined in the module {@link erl_syntax}.
-%%
-%% @type syntaxTree() = erl_syntax:syntaxTree(). An abstract syntax
-%% tree. See the {@link erl_syntax} module for details.
 
 -module(erl_syntax_lib).
 
@@ -46,9 +43,9 @@
 -export_type([info_pair/0]).
 
 %% =====================================================================
-%% @spec map(Function, Tree::syntaxTree()) -> syntaxTree()
+%% @spec map(Function, Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %%
-%%          Function = (syntaxTree()) -> syntaxTree()
+%%          Function = (erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %% 
 %% @doc Applies a function to each node of a syntax tree. The result of
 %% each application replaces the corresponding original node. The order
@@ -72,7 +69,7 @@ map(F, Tree) ->
 
 
 %% =====================================================================
-%% @spec map_subtrees(Function, syntaxTree()) -> syntaxTree()
+%% @spec map_subtrees(Function, erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %%
 %%          Function = (Tree) -> Tree1
 %%         
@@ -97,9 +94,9 @@ map_subtrees(F, Tree) ->
 
 
 %% =====================================================================
-%% @spec fold(Function, Start::term(), Tree::syntaxTree()) -> term()
+%% @spec fold(Function, Start::term(), Tree::erl_syntax:syntaxTree()) -> term()
 %%
-%%          Function = (syntaxTree(), term()) -> term()
+%%          Function = (erl_syntax:syntaxTree(), term()) -> term()
 %%
 %% @doc Folds a function over all nodes of a syntax tree. The result is
 %% the value of `Function(X1, Function(X2, ... Function(Xn, Start)
@@ -132,10 +129,10 @@ fold_2(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec fold_subtrees(Function, Start::term(), Tree::syntaxTree()) ->
+%% @spec fold_subtrees(Function, Start::term(), Tree::erl_syntax:syntaxTree()) ->
 %%           term()
 %%
-%%          Function = (syntaxTree(), term()) -> term()
+%%          Function = (erl_syntax:syntaxTree(), term()) -> term()
 %%
 %% @doc Folds a function over the immediate subtrees of a syntax tree.
 %% This is similar to `fold/3', but only on the immediate
@@ -176,10 +173,10 @@ foldl(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec mapfold(Function, Start::term(), Tree::syntaxTree()) ->
-%%           {syntaxTree(), term()}
+%% @spec mapfold(Function, Start::term(), Tree::erl_syntax:syntaxTree()) ->
+%%           {erl_syntax:syntaxTree(), term()}
 %%
-%%          Function = (syntaxTree(), term()) -> {syntaxTree(), term()}
+%%          Function = (erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}
 %%
 %% @doc Combines map and fold in a single operation. This is similar to
 %% `map/2', but also propagates an extra value from each
@@ -221,9 +218,9 @@ mapfold_2(_, S, []) ->
 
 %% =====================================================================
 %% @spec mapfold_subtrees(Function, Start::term(),
-%%                        Tree::syntaxTree()) -> {syntaxTree(), term()}
+%%                        Tree::erl_syntax:syntaxTree()) -> {erl_syntax:syntaxTree(), term()}
 %%
-%%          Function = (syntaxTree(), term()) -> {syntaxTree(), term()}
+%%          Function = (erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}
 %%
 %% @doc Does a mapfold operation over the immediate subtrees of a syntax
 %% tree. This is similar to `mapfold/3', but only on the
@@ -277,7 +274,7 @@ mapfoldl(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec variables(syntaxTree()) -> set(atom())
+%% @spec variables(erl_syntax:syntaxTree()) -> set(atom())
 %%
 %%        set(T) = //stdlib/sets:set(T)
 %%
@@ -453,10 +450,8 @@ new_variable_names(0, Names, _, _, _) ->
 
 
 %% =====================================================================
-%% @spec annotate_bindings(Tree::syntaxTree(),
-%%                         Bindings::ordset(atom())) -> syntaxTree()
-%%
-%% @type ordset(T) = //stdlib/ordsets:ordset(T)
+%% @spec annotate_bindings(Tree::erl_syntax:syntaxTree(),
+%%                         Bindings::ordsets:ordset(atom())) -> erl_syntax:syntaxTree()
 %%
 %% @doc Adds or updates annotations on nodes in a syntax tree.
 %% `Bindings' specifies the set of bound variables in the
@@ -487,7 +482,7 @@ annotate_bindings(Tree, Env) ->
     Tree1.
 
 %% =====================================================================
-%% @spec annotate_bindings(Tree::syntaxTree()) -> syntaxTree()
+%% @spec annotate_bindings(Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %%
 %% @doc Adds or updates annotations on nodes in a syntax tree.
 %% Equivalent to `annotate_bindings(Tree, Bindings)' where
@@ -888,7 +883,7 @@ delete_binding_anns([]) ->
 
 
 %% =====================================================================
-%% @spec is_fail_expr(Tree::syntaxTree()) -> boolean()
+%% @spec is_fail_expr(Tree::erl_syntax:syntaxTree()) -> boolean()
 %%
 %% @doc Returns `true' if `Tree' represents an
 %% expression which never terminates normally. Note that the reverse
@@ -938,7 +933,7 @@ is_fail_expr(E) ->
 %% =====================================================================
 %% @spec analyze_forms(Forms) -> [{Key, term()}]
 %%
-%%          Forms = syntaxTree() | [syntaxTree()]
+%%          Forms = erl_syntax:syntaxTree() | [erl_syntax:syntaxTree()]
 %%          Key = attributes | errors | exports | functions | imports
 %%                | module | records | warnings
 %%
@@ -1030,7 +1025,7 @@ is_fail_expr(E) ->
 %%       <dd><ul>
 %% 	    <li>`Records = [{atom(), Fields}]'</li>
 %% 	    <li>`Fields = [{atom(), Default}]'</li>
-%% 	    <li>`Default = none | syntaxTree()'</li>
+%% 	    <li>`Default = none | erl_syntax:syntaxTree()'</li>
 %%       </ul>
 %% 	 `Records' is a list of pairs representing the names
 %% 	 and corresponding field declarations of all record declaration
@@ -1184,7 +1179,7 @@ list_value(List) ->
 
 
 %% =====================================================================
-%% @spec analyze_form(Node::syntaxTree()) -> {atom(), term()} | atom()
+%% @spec analyze_form(Node::erl_syntax:syntaxTree()) -> {atom(), term()} | atom()
 %%
 %% @doc Analyzes a "source code form" node. If `Node' is a
 %% "form" type (cf. `erl_syntax:is_form/1'), the returned
@@ -1243,7 +1238,7 @@ analyze_form(Node) ->
     end.
 
 %% =====================================================================
-%% @spec analyze_attribute(Node::syntaxTree()) ->
+%% @spec analyze_attribute(Node::erl_syntax:syntaxTree()) ->
 %%           preprocessor | {atom(), atom()}
 %%
 %% @doc Analyzes an attribute node. If `Node' represents a
@@ -1334,7 +1329,7 @@ analyze_attribute(_, Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_module_attribute(Node::syntaxTree()) ->
+%% @spec analyze_module_attribute(Node::erl_syntax:syntaxTree()) ->
 %%           Name::atom() | {Name::atom(), Variables::[atom()]}
 %%
 %% @doc Returns the module name and possible parameters declared by a
@@ -1380,7 +1375,7 @@ analyze_variable_list(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_export_attribute(Node::syntaxTree()) -> [FunctionName]
+%% @spec analyze_export_attribute(Node::erl_syntax:syntaxTree()) -> [FunctionName]
 %%
 %%          FunctionName = atom() | {atom(), integer()}
 %%                       | {ModuleName, FunctionName}
@@ -1424,7 +1419,7 @@ analyze_function_name_list(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_function_name(Node::syntaxTree()) -> FunctionName
+%% @spec analyze_function_name(Node::erl_syntax:syntaxTree()) -> FunctionName
 %%
 %%          FunctionName = atom() | {atom(), integer()}
 %%                       | {ModuleName, FunctionName}
@@ -1481,7 +1476,7 @@ append_arity(_A, Name) ->
 
 
 %% =====================================================================
-%% @spec analyze_import_attribute(Node::syntaxTree()) ->
+%% @spec analyze_import_attribute(Node::erl_syntax:syntaxTree()) ->
 %%           {atom(), [FunctionName]} | atom()
 %%
 %%          FunctionName = atom() | {atom(), integer()}
@@ -1523,7 +1518,7 @@ analyze_import_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_wild_attribute(Node::syntaxTree()) -> {atom(), term()}
+%% @spec analyze_wild_attribute(Node::erl_syntax:syntaxTree()) -> {atom(), term()}
 %%
 %% @doc Returns the name and value of a "wild" attribute. The result is
 %% the pair `{Name, Value}', if `Node' represents "`-Name(Value)'".
@@ -1565,10 +1560,10 @@ analyze_wild_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_record_attribute(Node::syntaxTree()) ->
+%% @spec analyze_record_attribute(Node::erl_syntax:syntaxTree()) ->
 %%           {atom(), Fields}
 %%
-%%          Fields = [{atom(), none | syntaxTree()}]
+%%          Fields = [{atom(), none | erl_syntax:syntaxTree()}]
 %%
 %% @doc Returns the name and the list of fields of a record declaration
 %% attribute. The result is a pair `{Name, Fields}', if
@@ -1621,11 +1616,11 @@ analyze_record_attribute_tuple(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_record_expr(Node::syntaxTree()) ->
+%% @spec analyze_record_expr(Node::erl_syntax:syntaxTree()) ->
 %%     {atom(), Info} | atom()
 %%
 %%    Info = {atom(), [{atom(), Value}]} | {atom(), atom()} | atom()
-%%    Value = none | syntaxTree()
+%%    Value = none | erl_syntax:syntaxTree()
 %%
 %% @doc Returns the record name and field name/names of a record
 %% expression. If `Node' has type `record_expr',
@@ -1713,9 +1708,9 @@ analyze_record_expr(Node) ->
     end.
 
 %% =====================================================================
-%% @spec analyze_record_field(Node::syntaxTree()) -> {atom(), Value}
+%% @spec analyze_record_field(Node::erl_syntax:syntaxTree()) -> {atom(), Value}
 %%
-%%          Value = none | syntaxTree()
+%%          Value = none | erl_syntax:syntaxTree()
 %%
 %% @doc Returns the label and value-expression of a record field
 %% specifier. The result is a pair `{Label, Value}', if
@@ -1751,7 +1746,7 @@ analyze_record_field(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_file_attribute(Node::syntaxTree()) ->
+%% @spec analyze_file_attribute(Node::erl_syntax:syntaxTree()) ->
 %%           {string(), integer()}
 %%
 %% @doc Returns the file name and line number of a `file'
@@ -1788,7 +1783,7 @@ analyze_file_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_function(Node::syntaxTree()) -> {atom(), integer()}
+%% @spec analyze_function(Node::erl_syntax:syntaxTree()) -> {atom(), integer()}
 %%
 %% @doc Returns the name and arity of a function definition. The result
 %% is a pair `{Name, A}' if `Node' represents a
@@ -1818,7 +1813,7 @@ analyze_function(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_implicit_fun(Node::syntaxTree()) -> FunctionName
+%% @spec analyze_implicit_fun(Node::erl_syntax:syntaxTree()) -> FunctionName
 %%
 %%          FunctionName = atom() | {atom(), integer()}
 %%                       | {ModuleName, FunctionName}
@@ -1845,7 +1840,7 @@ analyze_implicit_fun(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_application(Node::syntaxTree()) -> FunctionName | Arity
+%% @spec analyze_application(Node::erl_syntax:syntaxTree()) -> FunctionName | Arity
 %%
 %%          FunctionName = {atom(), Arity}
 %%                       | {ModuleName, FunctionName}
@@ -1931,7 +1926,7 @@ function_name_expansions(A, Name, Ack) ->
 
 
 %% =====================================================================
-%% @spec strip_comments(Tree::syntaxTree()) -> syntaxTree()
+%% @spec strip_comments(Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %%
 %% @doc Removes all comments from all nodes of a syntax tree. All other
 %% attributes (such as position information) remain unchanged.
@@ -1957,7 +1952,7 @@ strip_comments_1(T) ->
     end.
 
 %% =====================================================================
-%% @spec to_comment(Tree) -> syntaxTree()
+%% @spec to_comment(Tree) -> erl_syntax:syntaxTree()
 %% @equiv to_comment(Tree, "% ")
 
 -spec to_comment(erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
@@ -1966,8 +1961,8 @@ to_comment(Tree) ->
     to_comment(Tree, "% ").
 
 %% =====================================================================
-%% @spec to_comment(Tree::syntaxTree(), Prefix::string()) ->
-%%           syntaxTree()
+%% @spec to_comment(Tree::erl_syntax:syntaxTree(), Prefix::string()) ->
+%%           erl_syntax:syntaxTree()
 %%
 %% @doc Equivalent to `to_comment(Tree, Prefix, F)' for a
 %% default formatting function `F'. The default
@@ -1983,10 +1978,10 @@ to_comment(Tree, Prefix) ->
     to_comment(Tree, Prefix, F).
 
 %% =====================================================================
-%% @spec to_comment(Tree::syntaxTree(), Prefix::string(), Printer) ->
-%%           syntaxTree()
+%% @spec to_comment(Tree::erl_syntax:syntaxTree(), Prefix::string(), Printer) ->
+%%           erl_syntax:syntaxTree()
 %%
-%%          Printer = (syntaxTree()) -> string()
+%%          Printer = (erl_syntax:syntaxTree()) -> string()
 %%
 %% @doc Transforms a syntax tree into an abstract comment. The lines of
 %% the comment contain the text for `Node', as produced by
@@ -2016,7 +2011,7 @@ to_comment(Tree, Prefix, F) ->
 
 
 %% =====================================================================
-%% @spec limit(Tree, Depth) -> syntaxTree()
+%% @spec limit(Tree, Depth) -> erl_syntax:syntaxTree()
 %%
 %% @doc Equivalent to `limit(Tree, Depth, Text)' using the
 %% text `"..."' as default replacement.
@@ -2030,8 +2025,8 @@ limit(Tree, Depth) ->
     limit(Tree, Depth, erl_syntax:text("...")).
 
 %% =====================================================================
-%% @spec limit(Tree::syntaxTree(), Depth::integer(),
-%%             Node::syntaxTree()) -> syntaxTree()
+%% @spec limit(Tree::erl_syntax:syntaxTree(), Depth::integer(),
+%%             Node::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
 %%
 %% @doc Limits a syntax tree to a specified depth. Replaces all non-leaf
 %% subtrees in `Tree' at the given `Depth' by

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -43,18 +43,15 @@
 -export_type([info_pair/0]).
 
 %% =====================================================================
-%% @spec map(Function, Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%%
-%%          Function = (erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%% 
 %% @doc Applies a function to each node of a syntax tree. The result of
 %% each application replaces the corresponding original node. The order
 %% of traversal is bottom-up.
 %%
 %% @see map_subtrees/2
 
--spec map(fun((erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()),
-	  erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
+-spec map(Function, Tree) -> erl_syntax:syntaxTree() when
+      Function :: fun((erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()),
+      Tree :: erl_syntax:syntaxTree().
 
 map(F, Tree) ->
     case erl_syntax:subtrees(Tree) of
@@ -69,18 +66,15 @@ map(F, Tree) ->
 
 
 %% =====================================================================
-%% @spec map_subtrees(Function, erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%%
-%%          Function = (Tree) -> Tree1
-%%         
 %% @doc Applies a function to each immediate subtree of a syntax tree.
 %% The result of each application replaces the corresponding original
 %% node.
 %%
 %% @see map/2
 
--spec map_subtrees(fun((erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()),
-		   erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
+-spec map_subtrees(Function, Tree) -> erl_syntax:syntaxTree() when
+      Function :: fun((erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()),
+      Tree :: erl_syntax:syntaxTree().
 
 map_subtrees(F, Tree) ->
     case erl_syntax:subtrees(Tree) of
@@ -94,10 +88,6 @@ map_subtrees(F, Tree) ->
 
 
 %% =====================================================================
-%% @spec fold(Function, Start::term(), Tree::erl_syntax:syntaxTree()) -> term()
-%%
-%%          Function = (erl_syntax:syntaxTree(), term()) -> term()
-%%
 %% @doc Folds a function over all nodes of a syntax tree. The result is
 %% the value of `Function(X1, Function(X2, ... Function(Xn, Start)
 %% ... ))', where `[X1, X2, ..., Xn]' are the nodes of
@@ -106,8 +96,10 @@ map_subtrees(F, Tree) ->
 %% @see fold_subtrees/3
 %% @see foldl_listlist/3
 
--spec fold(fun((erl_syntax:syntaxTree(), term()) -> term()),
-	   term(), erl_syntax:syntaxTree()) -> term().
+-spec fold(Function, Start, Tree) -> term() when
+      Function :: fun((erl_syntax:syntaxTree(), term()) -> term()),
+      Start :: term(),
+      Tree :: erl_syntax:syntaxTree().
 
 fold(F, S, Tree) ->
     case erl_syntax:subtrees(Tree) of
@@ -129,11 +121,6 @@ fold_2(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec fold_subtrees(Function, Start::term(), Tree::erl_syntax:syntaxTree()) ->
-%%           term()
-%%
-%%          Function = (erl_syntax:syntaxTree(), term()) -> term()
-%%
 %% @doc Folds a function over the immediate subtrees of a syntax tree.
 %% This is similar to `fold/3', but only on the immediate
 %% subtrees of `Tree', in left-to-right order; it does not
@@ -141,25 +128,25 @@ fold_2(_, S, []) ->
 %%
 %% @see fold/3
 
--spec fold_subtrees(fun((erl_syntax:syntaxTree(), term()) -> term()),
-		    term(), erl_syntax:syntaxTree()) -> term().
+-spec fold_subtrees(Function, Start, Tree) -> term() when
+      Function :: fun((erl_syntax:syntaxTree(), term()) -> term()),
+      Start :: term(),
+      Tree :: erl_syntax:syntaxTree().
 
 fold_subtrees(F, S, Tree) ->
     foldl_listlist(F, S, erl_syntax:subtrees(Tree)).
 
 
 %% =====================================================================
-%% @spec foldl_listlist(Function, Start::term(), [[term()]]) -> term()
-%%
-%%          Function = (term(), term()) -> term()
-%%
 %% @doc Like `lists:foldl/3', but over a list of lists.
 %%
 %% @see fold/3
 %% @see //stdlib/lists:foldl/3
 
--spec foldl_listlist(fun((term(), term()) -> term()),
-		     term(), [[term()]]) -> term().
+-spec foldl_listlist(Function, Start, ListOfLists) -> term() when
+      Function :: fun((term(), term()) -> term()),
+      Start :: term(),
+      ListOfLists :: [[term()]].
 
 foldl_listlist(F, S, [L | Ls]) ->
     foldl_listlist(F, foldl(F, S, L), Ls);
@@ -173,11 +160,6 @@ foldl(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec mapfold(Function, Start::term(), Tree::erl_syntax:syntaxTree()) ->
-%%           {erl_syntax:syntaxTree(), term()}
-%%
-%%          Function = (erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}
-%%
 %% @doc Combines map and fold in a single operation. This is similar to
 %% `map/2', but also propagates an extra value from each
 %% application of the `Function' to the next, while doing a
@@ -188,8 +170,10 @@ foldl(_, S, []) ->
 %% @see map/2
 %% @see fold/3
 
--spec mapfold(fun((erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}),
-	      term(), erl_syntax:syntaxTree()) -> {erl_syntax:syntaxTree(), term()}.
+-spec mapfold(Function, Start, Tree) -> {erl_syntax:syntaxTree(), term()} when
+      Function :: fun((erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}),
+      Start :: term(),
+      Tree :: erl_syntax:syntaxTree().
 
 mapfold(F, S, Tree) ->
     case erl_syntax:subtrees(Tree) of
@@ -217,11 +201,6 @@ mapfold_2(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec mapfold_subtrees(Function, Start::term(),
-%%                        Tree::erl_syntax:syntaxTree()) -> {erl_syntax:syntaxTree(), term()}
-%%
-%%          Function = (erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}
-%%
 %% @doc Does a mapfold operation over the immediate subtrees of a syntax
 %% tree. This is similar to `mapfold/3', but only on the
 %% immediate subtrees of `Tree', in left-to-right order; it
@@ -229,10 +208,10 @@ mapfold_2(_, S, []) ->
 %%
 %% @see mapfold/3
 
--spec mapfold_subtrees(fun((erl_syntax:syntaxTree(), term()) ->
-			      {erl_syntax:syntaxTree(), term()}),
-		       term(), erl_syntax:syntaxTree()) ->
-        {erl_syntax:syntaxTree(), term()}.
+-spec mapfold_subtrees(Function, Start, Tree) -> {erl_syntax:syntaxTree(), term()} when
+      Function :: fun((erl_syntax:syntaxTree(), term()) -> {erl_syntax:syntaxTree(), term()}),
+      Start :: term(),
+      Tree :: erl_syntax:syntaxTree().
 
 mapfold_subtrees(F, S, Tree) ->
     case erl_syntax:subtrees(Tree) of
@@ -246,17 +225,14 @@ mapfold_subtrees(F, S, Tree) ->
 
 
 %% =====================================================================
-%% @spec mapfoldl_listlist(Function, State, [[term()]]) ->
-%%           {[[term()]], term()}
-%%
-%%          Function = (term(), term()) -> {term(), term()}
-%%
 %% @doc Like `lists:mapfoldl/3', but over a list of lists.
 %% The list of lists in the result has the same structure as the given
 %% list of lists.
 
--spec mapfoldl_listlist(fun((term(), term()) -> {term(), term()}),
-			term(), [[term()]]) -> {[[term()]], term()}.
+-spec mapfoldl_listlist(Function, Start, ListOfLists) -> {[[term()]], term()} when
+      Function :: fun((term(), term()) -> {term(), term()}),
+      Start :: term(),
+      ListOfLists :: [[term()]].
 
 mapfoldl_listlist(F, S, [L | Ls]) ->
     {L1, S1} = mapfoldl(F, S, L),
@@ -274,17 +250,14 @@ mapfoldl(_, S, []) ->
 
 
 %% =====================================================================
-%% @spec variables(erl_syntax:syntaxTree()) -> set(atom())
-%%
-%%        set(T) = //stdlib/sets:set(T)
-%%
 %% @doc Returns the names of variables occurring in a syntax tree, The
 %% result is a set of variable names represented by atoms. Macro names
 %% are not included.
 %%
 %% @see //stdlib/sets
 
--spec variables(erl_syntax:syntaxTree()) -> sets:set(atom()).
+-spec variables(Tree) -> sets:set(atom()) when
+      Tree :: erl_syntax:syntaxTree().
 
 variables(Tree) ->
     variables(Tree, sets:new()).
@@ -330,8 +303,6 @@ default_variable_name(N) ->
     list_to_atom("V" ++ integer_to_list(N)).
 
 %% =====================================================================
-%% @spec new_variable_name(Used::set(atom())) -> atom()
-%%
 %% @doc Returns an atom which is not already in the set `Used'. This is
 %% equivalent to `new_variable_name(Function, Used)', where `Function'
 %% maps a given integer `N' to the atom whose name consists of "`V'"
@@ -339,16 +310,13 @@ default_variable_name(N) ->
 %%
 %% @see new_variable_name/2
 
--spec new_variable_name(sets:set(atom())) -> atom().
+-spec new_variable_name(Used) -> atom() when
+      Used :: sets:set(atom()).
 
 new_variable_name(S) ->
     new_variable_name(fun default_variable_name/1, S).
 
 %% =====================================================================
-%% @spec new_variable_name(Function, Used::set(atom())) -> atom()
-%%
-%%          Function = (integer()) -> atom()
-%%
 %% @doc Returns a user-named atom which is not already in the set
 %% `Used'. The atom is generated by applying the given
 %% `Function' to a generated integer. Integers are generated
@@ -365,7 +333,9 @@ new_variable_name(S) ->
 %% @see //stdlib/sets
 %% @see //stdlib/random
 
--spec new_variable_name(fun((integer()) -> atom()), sets:set(atom())) -> atom().
+-spec new_variable_name(Function, Used) -> atom() when
+      Function :: fun((integer()) -> atom()),
+      Used :: sets:set(atom()).
 
 new_variable_name(F, S) ->
     R = start_range(S),
@@ -411,31 +381,28 @@ generate(_Key, Range) ->
 
 
 %% =====================================================================
-%% @spec new_variable_names(N::integer(), Used::set(atom())) -> [atom()]
-%%
 %% @doc Like `new_variable_name/1', but generates a list of
 %% `N' new names.
-%% 
+%%
 %% @see new_variable_name/1
 
--spec new_variable_names(integer(), sets:set(atom())) -> [atom()].
+-spec new_variable_names(N, Used) -> [atom()] when
+      N :: integer(),
+      Used :: sets:set(atom()).
 
 new_variable_names(N, S) ->
     new_variable_names(N, fun default_variable_name/1, S).
 
 %% =====================================================================
-%% @spec new_variable_names(N::integer(), Function,
-%%                          Used::set(atom())) -> [atom()]
-%%
-%%          Function = (integer()) -> atom()
-%%
 %% @doc Like `new_variable_name/2', but generates a list of
 %% `N' new names.
-%% 
+%%
 %% @see new_variable_name/2
 
--spec new_variable_names(integer(), fun((integer()) -> atom()), sets:set(atom())) ->
-	[atom()].
+-spec new_variable_names(N, Function, Used) -> [atom()] when
+      N :: integer(),
+      Function :: fun((integer()) -> atom()),
+      Used ::sets:set(atom()).
 
 new_variable_names(N, F, S) when is_integer(N) ->
     R = start_range(S),
@@ -450,9 +417,6 @@ new_variable_names(0, Names, _, _, _) ->
 
 
 %% =====================================================================
-%% @spec annotate_bindings(Tree::erl_syntax:syntaxTree(),
-%%                         Bindings::ordsets:ordset(atom())) -> erl_syntax:syntaxTree()
-%%
 %% @doc Adds or updates annotations on nodes in a syntax tree.
 %% `Bindings' specifies the set of bound variables in the
 %% environment of the top level node. The following annotations are
@@ -474,16 +438,15 @@ new_variable_names(0, Names, _, _, _) ->
 %% @see annotate_bindings/1
 %% @see //stdlib/ordsets
 
--spec annotate_bindings(erl_syntax:syntaxTree(), ordsets:ordset(atom())) ->
-        erl_syntax:syntaxTree().
+-spec annotate_bindings(Tree, Bindings) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree(),
+      Bindings :: ordsets:ordset(atom()).
 
 annotate_bindings(Tree, Env) ->
     {Tree1, _, _} = vann(Tree, Env),
     Tree1.
 
 %% =====================================================================
-%% @spec annotate_bindings(Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%%
 %% @doc Adds or updates annotations on nodes in a syntax tree.
 %% Equivalent to `annotate_bindings(Tree, Bindings)' where
 %% the top-level environment `Bindings' is taken from the
@@ -493,7 +456,8 @@ annotate_bindings(Tree, Env) ->
 %%
 %% @see annotate_bindings/2
 
--spec annotate_bindings(erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
+-spec annotate_bindings(Tree) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree().
 
 annotate_bindings(Tree) ->
     As = erl_syntax:get_ann(Tree),
@@ -883,8 +847,6 @@ delete_binding_anns([]) ->
 
 
 %% =====================================================================
-%% @spec is_fail_expr(Tree::erl_syntax:syntaxTree()) -> boolean()
-%%
 %% @doc Returns `true' if `Tree' represents an
 %% expression which never terminates normally. Note that the reverse
 %% does not apply. Currently, the detected cases are calls to
@@ -896,9 +858,10 @@ delete_binding_anns([]) ->
 %% @see //erts/erlang:error/1
 %% @see //erts/erlang:error/2
 
--spec is_fail_expr(erl_syntax:syntaxTree()) -> boolean().
+-spec is_fail_expr(Tree) -> boolean() when
+      Tree :: erl_syntax:syntaxTree().
 
-is_fail_expr(E) ->          
+is_fail_expr(E) ->
     case erl_syntax:type(E) of
         application ->
             N = length(erl_syntax:application_arguments(E)),
@@ -931,12 +894,6 @@ is_fail_expr(E) ->
 
 
 %% =====================================================================
-%% @spec analyze_forms(Forms) -> [{Key, term()}]
-%%
-%%          Forms = erl_syntax:syntaxTree() | [erl_syntax:syntaxTree()]
-%%          Key = attributes | errors | exports | functions | imports
-%%                | module | records | warnings
-%%
 %% @doc Analyzes a sequence of "program forms". The given
 %% `Forms' may be a single syntax tree of type
 %% `form_list', or a list of "program form" syntax trees. The
@@ -1060,7 +1017,8 @@ is_fail_expr(E) ->
              | 'module' | 'records' | 'warnings'.
 -type info_pair() :: {key(), term()}.
 
--spec analyze_forms(erl_syntax:forms()) -> [info_pair()].
+-spec analyze_forms(Forms) -> [info_pair()] when
+      Forms :: erl_syntax:forms().
 
 analyze_forms(Forms) when is_list(Forms) ->
     finfo_to_list(lists:foldl(fun collect_form/2, new_finfo(), Forms));
@@ -1179,8 +1137,6 @@ list_value(List) ->
 
 
 %% =====================================================================
-%% @spec analyze_form(Node::erl_syntax:syntaxTree()) -> {atom(), term()} | atom()
-%%
 %% @doc Analyzes a "source code form" node. If `Node' is a
 %% "form" type (cf. `erl_syntax:is_form/1'), the returned
 %% value is a tuple `{Type, Info}' where `Type' is
@@ -1216,7 +1172,8 @@ list_value(List) ->
 %% @see erl_syntax:error_marker_info/1
 %% @see erl_syntax:warning_marker_info/1
 
--spec analyze_form(erl_syntax:syntaxTree()) -> {atom(), term()} | atom().
+-spec analyze_form(Node) -> {atom(), term()} | atom() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_form(Node) ->
     case erl_syntax:type(Node) of
@@ -1238,9 +1195,6 @@ analyze_form(Node) ->
     end.
 
 %% =====================================================================
-%% @spec analyze_attribute(Node::erl_syntax:syntaxTree()) ->
-%%           preprocessor | {atom(), atom()}
-%%
 %% @doc Analyzes an attribute node. If `Node' represents a
 %% preprocessor directive, the atom `preprocessor' is
 %% returned. Otherwise, if `Node' represents a module
@@ -1288,8 +1242,8 @@ analyze_form(Node) ->
 %% @see analyze_record_attribute/1
 %% @see analyze_wild_attribute/1
 
--spec analyze_attribute(erl_syntax:syntaxTree()) ->
-        'preprocessor' | {atom(), term()}.  % XXX: underspecified
+-spec analyze_attribute(Node) -> 'preprocessor' | {atom(), term()} when  % XXX: underspecified
+      Node :: erl_syntax:syntaxTree().
 
 analyze_attribute(Node) ->
     Name = erl_syntax:attribute_name(Node),
@@ -1329,9 +1283,6 @@ analyze_attribute(_, Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_module_attribute(Node::erl_syntax:syntaxTree()) ->
-%%           Name::atom() | {Name::atom(), Variables::[atom()]}
-%%
 %% @doc Returns the module name and possible parameters declared by a
 %% module attribute. If the attribute is a plain module declaration such
 %% as `-module(name)', the result is the module name. If the attribute
@@ -1344,8 +1295,8 @@ analyze_attribute(_, Node) ->
 %%
 %% @see analyze_attribute/1
 
--spec analyze_module_attribute(erl_syntax:syntaxTree()) ->
-        atom() | {atom(), [atom()]}.
+-spec analyze_module_attribute(Node) -> atom() | {atom(), [atom()]} when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_module_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1375,12 +1326,6 @@ analyze_variable_list(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_export_attribute(Node::erl_syntax:syntaxTree()) -> [FunctionName]
-%%
-%%          FunctionName = atom() | {atom(), integer()}
-%%                       | {ModuleName, FunctionName}
-%%          ModuleName = atom()
-%%
 %% @doc Returns the list of function names declared by an export
 %% attribute. We do not guarantee that each name occurs at most once in
 %% the list. The order of listing is not defined.
@@ -1391,9 +1336,10 @@ analyze_variable_list(Node) ->
 %% @see analyze_attribute/1
 
 -type functionN()    :: atom() | {atom(), arity()}.
--type functionName() :: functionN() | {atom(), functionN()}.
+-type functionName() :: functionN() | {module(), functionN()}.
 
--spec analyze_export_attribute(erl_syntax:syntaxTree()) -> [functionName()].
+-spec analyze_export_attribute(Node) -> [functionName()] when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_export_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1419,12 +1365,6 @@ analyze_function_name_list(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_function_name(Node::erl_syntax:syntaxTree()) -> FunctionName
-%%
-%%          FunctionName = atom() | {atom(), integer()}
-%%                       | {ModuleName, FunctionName}
-%%          ModuleName = atom()
-%%
 %% @doc Returns the function name represented by a syntax tree. If
 %% `Node' represents a function name, such as
 %% "`foo/1'" or "`bloggs:fred/2'", a uniform
@@ -1435,7 +1375,8 @@ analyze_function_name_list(Node) ->
 %% The evaluation throws `syntax_error' if
 %% `Node' does not represent a well-formed function name.
 
--spec analyze_function_name(erl_syntax:syntaxTree()) -> functionName().
+-spec analyze_function_name(Node) -> functionName() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_function_name(Node) ->
     case erl_syntax:type(Node) of
@@ -1476,13 +1417,6 @@ append_arity(_A, Name) ->
 
 
 %% =====================================================================
-%% @spec analyze_import_attribute(Node::erl_syntax:syntaxTree()) ->
-%%           {atom(), [FunctionName]} | atom()
-%%
-%%          FunctionName = atom() | {atom(), integer()}
-%%                       | {ModuleName, FunctionName}
-%%          ModuleName = atom()
-%%
 %% @doc Returns the module name and (if present) list of function names
 %% declared by an import attribute. The returned value is an atom
 %% `Module' or a pair `{Module, Names}', where
@@ -1496,8 +1430,8 @@ append_arity(_A, Name) ->
 %%
 %% @see analyze_attribute/1
 
--spec analyze_import_attribute(erl_syntax:syntaxTree()) ->
-        {atom(), [functionName()]} | atom().
+-spec analyze_import_attribute(Node) -> {atom(), [functionName()]} | atom() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_import_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1518,8 +1452,6 @@ analyze_import_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_wild_attribute(Node::erl_syntax:syntaxTree()) -> {atom(), term()}
-%%
 %% @doc Returns the name and value of a "wild" attribute. The result is
 %% the pair `{Name, Value}', if `Node' represents "`-Name(Value)'".
 %%
@@ -1532,7 +1464,8 @@ analyze_import_attribute(Node) ->
 %%
 %% @see analyze_attribute/1
 
--spec analyze_wild_attribute(erl_syntax:syntaxTree()) -> {atom(), term()}.
+-spec analyze_wild_attribute(Node) -> {atom(), term()} when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_wild_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1560,11 +1493,6 @@ analyze_wild_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_record_attribute(Node::erl_syntax:syntaxTree()) ->
-%%           {atom(), Fields}
-%%
-%%          Fields = [{atom(), none | erl_syntax:syntaxTree()}]
-%%
 %% @doc Returns the name and the list of fields of a record declaration
 %% attribute. The result is a pair `{Name, Fields}', if
 %% `Node' represents "`-record(Name, {...}).'",
@@ -1584,7 +1512,8 @@ analyze_wild_attribute(Node) ->
 
 -type fields() :: [{atom(), 'none' | erl_syntax:syntaxTree()}].
 
--spec analyze_record_attribute(erl_syntax:syntaxTree()) -> {atom(), fields()}.
+-spec analyze_record_attribute(Node) -> {atom(), fields()} when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_record_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1616,12 +1545,6 @@ analyze_record_attribute_tuple(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_record_expr(Node::erl_syntax:syntaxTree()) ->
-%%     {atom(), Info} | atom()
-%%
-%%    Info = {atom(), [{atom(), Value}]} | {atom(), atom()} | atom()
-%%    Value = none | erl_syntax:syntaxTree()
-%%
 %% @doc Returns the record name and field name/names of a record
 %% expression. If `Node' has type `record_expr',
 %% `record_index_expr' or `record_access', a pair
@@ -1657,7 +1580,8 @@ analyze_record_attribute_tuple(Node) ->
 -type info() :: {atom(), [{atom(), 'none' | erl_syntax:syntaxTree()}]}
               | {atom(), atom()} | atom().
 
--spec analyze_record_expr(erl_syntax:syntaxTree()) -> {atom(), info()} | atom().
+-spec analyze_record_expr(Node) -> {atom(), info()} | atom() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_record_expr(Node) ->
     case erl_syntax:type(Node) of
@@ -1708,10 +1632,6 @@ analyze_record_expr(Node) ->
     end.
 
 %% =====================================================================
-%% @spec analyze_record_field(Node::erl_syntax:syntaxTree()) -> {atom(), Value}
-%%
-%%          Value = none | erl_syntax:syntaxTree()
-%%
 %% @doc Returns the label and value-expression of a record field
 %% specifier. The result is a pair `{Label, Value}', if
 %% `Node' represents "`Label = <em>Value</em>'" or
@@ -1726,8 +1646,9 @@ analyze_record_expr(Node) ->
 %% @see analyze_record_attribute/1
 %% @see analyze_record_expr/1
 
--spec analyze_record_field(erl_syntax:syntaxTree()) ->
-        {atom(), 'none' | erl_syntax:syntaxTree()}.
+-spec analyze_record_field(Node) -> {atom(), Value} when
+      Node :: erl_syntax:syntaxTree(),
+      Value :: 'none' | erl_syntax:syntaxTree().
 
 analyze_record_field(Node) ->
     case erl_syntax:type(Node) of
@@ -1746,9 +1667,6 @@ analyze_record_field(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_file_attribute(Node::erl_syntax:syntaxTree()) ->
-%%           {string(), integer()}
-%%
 %% @doc Returns the file name and line number of a `file'
 %% attribute. The result is the pair `{File, Line}' if
 %% `Node' represents "`-file(File, Line).'".
@@ -1759,7 +1677,8 @@ analyze_record_field(Node) ->
 %%
 %% @see analyze_attribute/1
 
--spec analyze_file_attribute(erl_syntax:syntaxTree()) -> {string(), integer()}.
+-spec analyze_file_attribute(Node) -> {string(), integer()} when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_file_attribute(Node) ->
     case erl_syntax:type(Node) of
@@ -1783,8 +1702,6 @@ analyze_file_attribute(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_function(Node::erl_syntax:syntaxTree()) -> {atom(), integer()}
-%%
 %% @doc Returns the name and arity of a function definition. The result
 %% is a pair `{Name, A}' if `Node' represents a
 %% function definition "`Name(<em>P_1</em>, ..., <em>P_A</em>) ->
@@ -1794,7 +1711,8 @@ analyze_file_attribute(Node) ->
 %% `Node' does not represent a well-formed function
 %% definition.
 
--spec analyze_function(erl_syntax:syntaxTree()) -> {atom(), arity()}.
+-spec analyze_function(Node) -> {atom(), arity()} when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_function(Node) ->
     case erl_syntax:type(Node) of
@@ -1813,12 +1731,6 @@ analyze_function(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_implicit_fun(Node::erl_syntax:syntaxTree()) -> FunctionName
-%%
-%%          FunctionName = atom() | {atom(), integer()}
-%%                       | {ModuleName, FunctionName}
-%%          ModuleName = atom()
-%%      
 %% @doc Returns the name of an implicit fun expression "`fun
 %% <em>F</em>'". The result is a representation of the function
 %% name `F'. (Cf. `analyze_function_name/1'.)
@@ -1828,7 +1740,8 @@ analyze_function(Node) ->
 %%
 %% @see analyze_function_name/1
 
--spec analyze_implicit_fun(erl_syntax:syntaxTree()) -> functionName().
+-spec analyze_implicit_fun(Node) -> functionName() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_implicit_fun(Node) ->
     case erl_syntax:type(Node) of
@@ -1840,13 +1753,6 @@ analyze_implicit_fun(Node) ->
 
 
 %% =====================================================================
-%% @spec analyze_application(Node::erl_syntax:syntaxTree()) -> FunctionName | Arity
-%%
-%%          FunctionName = {atom(), Arity}
-%%                       | {ModuleName, FunctionName}
-%%          Arity = integer()
-%%          ModuleName = atom()
-%%
 %% @doc Returns the name of a called function. The result is a
 %% representation of the name of the applied function `F/A',
 %% if `Node' represents a function application
@@ -1859,9 +1765,10 @@ analyze_implicit_fun(Node) ->
 %%
 %% @see analyze_function_name/1
 
--type appFunName() :: {atom(), arity()} | {atom(), {atom(), arity()}}.
+-type appFunName() :: {atom(), arity()} | {module(), {atom(), arity()}}.
 
--spec analyze_application(erl_syntax:syntaxTree()) -> appFunName() | arity().
+-spec analyze_application(Node) -> appFunName() | arity() when
+      Node :: erl_syntax:syntaxTree().
 
 analyze_application(Node) ->
     case erl_syntax:type(Node) of
@@ -1882,11 +1789,6 @@ analyze_application(Node) ->
 
 
 %% =====================================================================
-%% @spec function_name_expansions(Names::[Name]) -> [{ShortName, Name}]
-%%
-%%          Name = ShortName | {atom(), Name}
-%%          ShortName = atom() | {atom(), integer()}
-%%
 %% @doc Creates a mapping from corresponding short names to full
 %% function names. Names are represented by nested tuples of atoms and
 %% integers (cf. `analyze_function_name/1'). The result is a
@@ -1906,7 +1808,8 @@ analyze_application(Node) ->
 -type shortname() :: atom() | {atom(), arity()}.
 -type name()      :: shortname() | {atom(), shortname()}.
 
--spec function_name_expansions([name()]) -> [{shortname(), name()}].
+-spec function_name_expansions(Names) -> [{shortname(), name()}] when
+      Names :: [name()].
 
 function_name_expansions(Fs) ->
     function_name_expansions(Fs, []).
@@ -1926,14 +1829,13 @@ function_name_expansions(A, Name, Ack) ->
 
 
 %% =====================================================================
-%% @spec strip_comments(Tree::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%%
 %% @doc Removes all comments from all nodes of a syntax tree. All other
 %% attributes (such as position information) remain unchanged.
 %% Standalone comments in form lists are removed; any other standalone
 %% comments are changed into null-comments (no text, no indentation).
 
--spec strip_comments(erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
+-spec strip_comments(Tree) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree().
 
 strip_comments(Tree) ->
     map(fun strip_comments_1/1, Tree).
@@ -1952,37 +1854,27 @@ strip_comments_1(T) ->
     end.
 
 %% =====================================================================
-%% @spec to_comment(Tree) -> erl_syntax:syntaxTree()
 %% @equiv to_comment(Tree, "% ")
 
--spec to_comment(erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree().
+-spec to_comment(Tree) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree().
 
 to_comment(Tree) ->
     to_comment(Tree, "% ").
 
 %% =====================================================================
-%% @spec to_comment(Tree::erl_syntax:syntaxTree(), Prefix::string()) ->
-%%           erl_syntax:syntaxTree()
-%%
-%% @doc Equivalent to `to_comment(Tree, Prefix, F)' for a
-%% default formatting function `F'. The default
-%% `F' simply calls `erl_prettypr:format/1'.
-%%
-%% @see to_comment/3
+%% @equiv to_comment(Tree, Prefix, fun erl_prettypr:format/1)
 %% @see erl_prettypr:format/1
 
--spec to_comment(erl_syntax:syntaxTree(), string()) -> erl_syntax:syntaxTree().
+-spec to_comment(Tree, Prefix) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree(),
+      Prefix :: string().
 
 to_comment(Tree, Prefix) ->
-    F = fun (T) -> erl_prettypr:format(T) end,
+    F = fun erl_prettypr:format/1,
     to_comment(Tree, Prefix, F).
 
 %% =====================================================================
-%% @spec to_comment(Tree::erl_syntax:syntaxTree(), Prefix::string(), Printer) ->
-%%           erl_syntax:syntaxTree()
-%%
-%%          Printer = (erl_syntax:syntaxTree()) -> string()
-%%
 %% @doc Transforms a syntax tree into an abstract comment. The lines of
 %% the comment contain the text for `Node', as produced by
 %% the given `Printer' function. Each line of the comment is
@@ -2002,32 +1894,27 @@ to_comment(Tree, Prefix) ->
 %% @see to_comment/1
 %% @see to_comment/2
 
--spec to_comment(erl_syntax:syntaxTree(), string(),
-		 fun((erl_syntax:syntaxTree()) -> string())) ->
-        erl_syntax:syntaxTree().
+-spec to_comment(Tree, Prefix, Printer) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree(),
+      Prefix :: string(),
+      Printer :: fun((erl_syntax:syntaxTree()) -> string()).
 
 to_comment(Tree, Prefix, F) ->
     erl_syntax:comment(split_lines(F(Tree), Prefix)).
 
 
 %% =====================================================================
-%% @spec limit(Tree, Depth) -> erl_syntax:syntaxTree()
-%%
-%% @doc Equivalent to `limit(Tree, Depth, Text)' using the
-%% text `"..."' as default replacement.
-%%
-%% @see limit/3
+%% @equiv limit(Tree, Depth, erl_syntax:text("..."))
 %% @see erl_syntax:text/1
 
--spec limit(erl_syntax:syntaxTree(), integer()) -> erl_syntax:syntaxTree().
+-spec limit(Tree, Depth) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree(),
+      Depth :: integer().
 
 limit(Tree, Depth) ->
     limit(Tree, Depth, erl_syntax:text("...")).
 
 %% =====================================================================
-%% @spec limit(Tree::erl_syntax:syntaxTree(), Depth::integer(),
-%%             Node::erl_syntax:syntaxTree()) -> erl_syntax:syntaxTree()
-%%
 %% @doc Limits a syntax tree to a specified depth. Replaces all non-leaf
 %% subtrees in `Tree' at the given `Depth' by
 %% `Node'. If `Depth' is negative, the result is
@@ -2049,8 +1936,10 @@ limit(Tree, Depth) ->
 %%
 %% @see limit/2
 
--spec limit(erl_syntax:syntaxTree(), integer(), erl_syntax:syntaxTree()) ->
-        erl_syntax:syntaxTree().
+-spec limit(Tree, Depth, Node) -> erl_syntax:syntaxTree() when
+      Tree :: erl_syntax:syntaxTree(),
+      Depth :: integer(),
+      Node :: erl_syntax:syntaxTree().
 
 limit(_Tree, Depth, Node) when Depth < 0 ->
     Node;

--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -269,9 +269,10 @@ cont_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     S#xmerl_scanner{fun_states = FS1}.
 
 
-%% @spec file(Filename::string()) -> {xmlElement(),Rest}
-%%   Rest = list()
 %% @equiv file(Filename, [])
+-spec file(Filename) -> {document(),Rest} when
+      Filename :: string(),
+      Rest :: list().
 file(F) ->
     file(F, []).
 
@@ -311,9 +312,10 @@ int_file_decl(F, Options,_ExtCharset) ->
 	    Error
     end.
 
-%% @spec string(Text::list()) -> {xmlElement(),Rest}
-%%   Rest = list()
 %% @equiv string(Test, [])
+-spec string(Text) -> {document(),Rest} when
+      Text :: list(),
+      Rest :: list().
 string(Str) ->
     string(Str, []).
 

--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -27,9 +27,7 @@
 %%     It returns records of the type defined in xmerl.hrl.
 %% See also <a href="xmerl_examples.html">tutorial</a> on customization
 %% functions.
-%% @type global_state(). <p>
-%% The global state of the scanner, represented by the #xmerl_scanner{} record.
-%% </p>
+%%
 %% @type option_list(). <p>Options allow to customize the behaviour of the
 %%     scanner.
 %% See also <a href="xmerl_examples.html">tutorial</a> on customization
@@ -93,7 +91,7 @@
 %%  <dt><code>{doctype_DTD, DTD}</code></dt>
 %%    <dd>Allows to specify DTD name when it isn't available in the XML
 %%    document. This option has effect only together with
-%%    <code>{validation,'dtd'</code> option.</dd>
+%%    <code>{validation, 'dtd'}</code> option.</dd>
 %%  <dt><code>{xmlbase, Dir}</code></dt>
 %%    <dd>XML Base directory. If using string/1 default is current directory.
 %%    If using file/1 default is directory of given file.</dd>
@@ -111,11 +109,6 @@
 %%    <dd>Set to 'true' if xmerl should add to elements missing attributes
 %%    with a defined default value (default 'false').</dd>
 %% </dl>
-%% @type document() = xmlElement() | xmlDocument(). <p>
-%% The document returned by <tt>xmerl_scan:string/[1,2]</tt> and
-%% <tt>xmerl_scan:file/[1,2]</tt>. The type of the returned record depends on
-%% the value of the document option passed to the function.
-%% </p>
 
 
 -module(xmerl_scan).
@@ -143,6 +136,42 @@
 -include_lib("kernel/include/file.hrl").
 
 
+-type global_state() :: #xmerl_scanner{}.
+%% The global state of the scanner, represented by the #xmerl_scanner{} record.
+
+-type document() :: #xmlElement{} | #xmlDocument{}.
+%% The document returned by <tt>xmerl_scan:string/[1,2]</tt> and
+%% <tt>xmerl_scan:file/[1,2]</tt>. The type of the returned record depends on
+%% the value of the document option passed to the function.
+
+-type option_list() :: {acc_fun, fun()} |
+                       {continuation_fun, fun()} |
+                       {continuation_fun, fun(), ContinuationState::global_state()} |
+                       {event_fun, fun()} |
+                       {event_fun, fun(), EventState::global_state()} |
+                       {fetch_fun, fun()} |
+                       {fetch_fun, fun(), FetchState::global_state()} |
+                       {hook_fun, fun()} |
+                       {hook_fun, fun(), HookState::global_state()} |
+                       {close_fun, fun()} |
+                       {rules, ReadFun::fun(), WriteFun::fun(), RulesState::global_state()} |
+                       {rules, ets:tab()} |
+                       {user_state, global_state()} |
+                       {fetch_path, PathList::[string()]} |
+                       {space, boolean()} |
+                       {line, pos_integer()} |
+                       {namespace_conformant, boolean()} |
+                       {validation, boolean()} |
+                       {schemaLocation, string() | [{Namespace::string(),Link::string()},...]} |
+                       {quiet, boolean()} |
+                       {doctype_DTD, atom() | string()} |
+                       {xmlbase, Dir::string()} |
+                       {encoding, undefined | string()} |
+                       {document, boolean()} |
+                       {comments, boolean()} |
+                       {default_attrs, boolean()}.
+
+
 -define(fatal(Reason, S),
 	if
 	    S#xmerl_scanner.quiet ->
@@ -159,76 +188,82 @@
 
 %% Functions to access the various states
 
-%%% @spec user_state(S::global_state()) -> global_state()
-%%% @equiv user_state(UserState,S)
+%%% @equiv user_state(UserState, S)
+-spec user_state(S::global_state()) -> global_state().
 user_state(#xmerl_scanner{user_state = S}) -> S.
 
-%%% @spec event_state(S::global_state()) -> global_state()
-%%% @equiv event_state(EventState,S)
+%%% @equiv event_state(EventState, S)
+-spec event_state(S::global_state()) -> global_state().
 event_state(#xmerl_scanner{fun_states = #xmerl_fun_states{event = S}}) -> S.
 
-%%% @spec hook_state(S::global_state()) -> global_state()
-%%% @equiv hook_state(HookState,S)
+%%% @equiv hook_state(HookState, S)
+-spec hook_state(S::global_state()) -> global_state().
 hook_state(#xmerl_scanner{fun_states = #xmerl_fun_states{hook = S}}) -> S.
 
-%%% @spec rules_state(S::global_state()) -> global_state()
-%%% @equiv rules_state(RulesState,S)
+%%% @equiv rules_state(RulesState, S)
+-spec rules_state(S::global_state()) -> global_state().
 rules_state(#xmerl_scanner{fun_states = #xmerl_fun_states{rules = S}}) -> S.
 
-%%% @spec fetch_state(S::global_state()) -> global_state()
-%%% @equiv fetch_state(FetchState,S)
+%%% @equiv fetch_state(FetchState, S)
+-spec fetch_state(S::global_state()) -> global_state().
 fetch_state(#xmerl_scanner{fun_states = #xmerl_fun_states{fetch = S}}) -> S.
 
-%%% @spec cont_state(S::global_state()) -> global_state()
-%%% @equiv cont_state(ContinuationState,S)
+%%% @equiv cont_state(ContinuationState, S)
+-spec cont_state(S::global_state()) -> global_state().
 cont_state(#xmerl_scanner{fun_states = #xmerl_fun_states{cont = S}}) -> S.
 
 
 %%%% Functions to modify the various states
 
-%%% @spec user_state(UserState, S::global_state()) -> global_state()
 %%% @doc For controlling the UserState, to be used in a user function.
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec user_state(UserState::global_state(), S::global_state()) -> global_state().
 user_state(X, S) ->
     S#xmerl_scanner{user_state = X}.
 
-%%% @spec event_state(EventState, S::global_state()) -> global_state()
 %%% @doc For controlling the EventState, to be used in an event
 %%% function, and called at the beginning and at the end of a parsed entity.
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec event_state(EventState::global_state(), S::global_state()) -> global_state().
 event_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     FS1 = FS#xmerl_fun_states{event = X},
     S#xmerl_scanner{fun_states = FS1}.
 
-%%% @spec hook_state(HookState, S::global_state()) -> global_state()
 %%% @doc For controlling the HookState, to be used in a hook
 %%% function, and called when the parser has parsed a complete entity.
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec hook_state(HookState::global_state(), S::global_state()) -> global_state().
 hook_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     FS1 = FS#xmerl_fun_states{hook = X},
     S#xmerl_scanner{fun_states = FS1}.
 
-%%% @spec rules_state(RulesState, S::global_state()) -> global_state()
 %%% @doc For controlling the RulesState, to be used in a rules
 %%% function, and called when the parser store scanner information in a rules
 %%% database.
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec rules_state(RulesState::global_state(), S::global_state()) -> global_state().
 rules_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     FS1 = FS#xmerl_fun_states{rules = X},
     S#xmerl_scanner{fun_states = FS1}.
 
-%%% @spec fetch_state(FetchState, S::global_state()) -> global_state()
 %%% @doc For controlling the FetchState, to be used in a fetch
 %%% function, and called when the parser fetch an external resource (eg. a DTD).
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec fetch_state(FetchState::global_state(), S::global_state()) -> global_state().
 fetch_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     FS1 = FS#xmerl_fun_states{fetch = X},
     S#xmerl_scanner{fun_states = FS1}.
 
-%%% @spec cont_state(ContinuationState, S::global_state()) -> global_state()
 %%% @doc For controlling the ContinuationState, to be used in a continuation
 %%% function, and called when the parser encounters the end of the byte stream.
 %%% See <a href="xmerl_examples.html">tutorial</a> on customization functions.
+%%% @end
+-spec cont_state(ContinuationState::global_state(), S::global_state()) -> global_state().
 cont_state(X, S=#xmerl_scanner{fun_states = FS}) ->
     FS1 = FS#xmerl_fun_states{cont = X},
     S#xmerl_scanner{fun_states = FS1}.
@@ -240,9 +275,11 @@ cont_state(X, S=#xmerl_scanner{fun_states = FS}) ->
 file(F) ->
     file(F, []).
 
-%% @spec file(Filename::string(), Options::option_list()) -> {document(),Rest}
-%%   Rest = list()
 %%% @doc Parse file containing an XML document
+-spec file(Filename, Options) -> {document(),Rest} when
+      Filename :: string(),
+      Options :: option_list(),
+      Rest :: list().
 file(F, Options) ->
     ExtCharset=case lists:keysearch(encoding,1,Options) of
 		   {value,{_,Val}} -> Val;
@@ -280,9 +317,11 @@ int_file_decl(F, Options,_ExtCharset) ->
 string(Str) ->
     string(Str, []).
 
-%% @spec string(Text::list(),Options::option_list()) -> {document(),Rest}
-%%   Rest = list()
 %%% @doc Parse string containing an XML document
+-spec string(Text, Options) -> {document(),Rest} when
+      Text :: list(),
+      Options :: option_list(),
+      Rest :: list().
 string(Str, Options) ->
      {Res, Tail, S=#xmerl_scanner{close_fun = Close}} =
 	int_string(Str, Options,file_name_unknown),
@@ -3999,10 +4038,14 @@ fast_acc_end(T, S, N, Col, C, CD_I) ->
     end.
 
 
-%%% @spec accumulate_whitespace(T::string(),S::global_state(),
-%%%                             atom(),Acc::string()) -> {Acc, T1, S1}
-%%%
 %%% @doc Function to accumulate and normalize whitespace.
+-spec accumulate_whitespace(T, S, X3, Acc) -> {Acc, T1, S1} when
+      T :: string(),
+      T1 :: string(),
+      S :: global_state(),
+      S1 :: global_state(),
+      X3 :: atom(),
+      Acc :: string().
 accumulate_whitespace(T, S, preserve, Acc) ->
     accumulate_whitespace(T, S, Acc);
 accumulate_whitespace(T, S, normalize, Acc) ->

--- a/lib/xmerl/src/xmerl_xpath.erl
+++ b/lib/xmerl/src/xmerl_xpath.erl
@@ -105,14 +105,20 @@
 
 
 
-
-%% @spec string(Str, Doc) -> [nodeEntity()] | Scalar
 %% @equiv string(Str, Doc, [])
+-spec string(Str, Doc) -> [nodeEntity()] | Scalar when
+      Str     :: xPathString(),
+      Doc     :: nodeEntity(),
+      Scalar  :: #xmlObj{}.
 string(Str, Doc) ->
     string(Str, Doc, []).
 
-%% @spec string(Str, Doc, Options) -> [nodeEntity()] | Scalar
 %% @equiv string(Str, Doc, [], Doc, Options)
+-spec string(Str, Doc, Options) -> [nodeEntity()] | Scalar when
+      Str     :: xPathString(),
+      Doc     :: nodeEntity(),
+      Options :: option_list(),
+      Scalar  :: #xmlObj{}.
 string(Str, Doc, Options) ->
     string(Str, Doc, [], Doc, Options).
 

--- a/lib/xmerl/src/xmerl_xpath.erl
+++ b/lib/xmerl/src/xmerl_xpath.erl
@@ -41,15 +41,7 @@
 % xmerl_xpath_parse:parse(xmerl_xpath_scan:tokens("descendant-or-self::node()")).
 % xmerl_xpath_parse:parse(xmerl_xpath_scan:tokens("parent::processing-instruction('foo')")).
 %% </pre>
-%%
-%% @type nodeEntity() =
-%%      xmlElement()
-%%    | xmlAttribute()
-%%    | xmlText() 
-%%    | xmlPI()
-%%    | xmlComment()
-%%    | xmlNsNode()
-%%    | xmlDocument()
+
 %% @type option_list(). <p>Options allows to customize the behaviour of the
 %%     XPath scanner.
 %% </p>
@@ -62,11 +54,11 @@
 %%  <dt><code>{namespace, Nodes}</code></dt>
 %%    <dd>Set namespace nodes in xmlContext.</dd>
 %% </dl>
-
 %%  <dt><code>{bindings, Bs}</code></dt>
 %%   <dd></dd>
 %% <dt><code>{functions, Fs}</code></dt>
 %%   <dd></dd>
+
 -module(xmerl_xpath).
 
 
@@ -87,6 +79,23 @@
 -include("xmerl_internal.hrl").
 
 
+-type option_list() :: {namespace, #xmlNamespace{}} |
+                       {namespace, Nodes :: [{Prefix::atom() | string(), URI::atom() | string()}]} |
+                       {bindings, Bs :: list()} |
+                       {functions, Fs :: list()}.
+
+-type nodeEntity() :: #xmlElement{} |
+                      #xmlAttribute{} |
+                      #xmlText{} |
+                      #xmlPI{} |
+                      #xmlComment{} |
+                      #xmlNsNode{} |
+                      #xmlDocument{}.
+
+-type xPathString() :: string().
+
+-type parentList() :: [{atom(), integer()}].
+
 -record(state, {context = #xmlContext{},
 		acc = []}).
 
@@ -97,28 +106,27 @@
 
 
 
-%% @spec string(Str, Doc) -> [docEntity()] | Scalar
-%% @equiv string(Str,Doc, [])
+%% @spec string(Str, Doc) -> [nodeEntity()] | Scalar
+%% @equiv string(Str, Doc, [])
 string(Str, Doc) ->
     string(Str, Doc, []).
 
-%% @spec string(Str,Doc,Options) -> 
-%%      [docEntity()] | Scalar
-%% @equiv string(Str,Doc, [],Doc,Options)
+%% @spec string(Str, Doc, Options) -> [nodeEntity()] | Scalar
+%% @equiv string(Str, Doc, [], Doc, Options)
 string(Str, Doc, Options) ->
     string(Str, Doc, [], Doc, Options).
 
-%% @spec string(Str,Node,Parents,Doc,Options) ->
-%%      [docEntity()] | Scalar
-%%   Str     = xPathString()
-%%   Node    = nodeEntity()
-%%   Parents = parentList()
-%%   Doc     = nodeEntity()
-%%   Options = option_list()
-%%   Scalar  = xmlObj
 %% @doc Extracts the nodes from the parsed XML tree according to XPath.
 %%   xmlObj is a record with fields type and value,
 %%   where type is boolean | number | string
+%% @end
+-spec string(Str, Node, Parents, Doc, Options) -> [nodeEntity()] | Scalar when
+      Str     :: xPathString(),
+      Node    :: nodeEntity(),
+      Parents :: parentList(),
+      Doc     :: nodeEntity(),
+      Options :: option_list(),
+      Scalar  :: #xmlObj{}.
 string(Str, Node, Parents, Doc, Options) ->
 %% record with fields type and value,
 %%                where type is boolean | number | string

--- a/lib/xmerl/src/xmerl_xsd.erl
+++ b/lib/xmerl/src/xmerl_xsd.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 
-%% @doc Interface module for XML Schema vlidation. 
+%% @doc Interface module for XML Schema vqlidation. 
 %% It handles the W3.org 
 %% <a href="http://www.w3.org/XML/Schema#dev">specifications</a>
 %% of XML Schema second edition 28 october 2004. For an introduction to
@@ -33,8 +33,8 @@
 %% <dl>
 %%   <dt><code>{tab2file,boolean()}</code></dt>
 %%      <dd>Enables saving of abstract structure on file for debugging
-%%         purpose.</dd>
-%%   <dt><code>{xsdbase,filename()}</code></dt>
+%%         purposes.</dd>
+%%   <dt><code>{xsdbase,file:name()}</code></dt>
 %%      <dd>XSD Base directory.</dd>
 %%   <dt><code>{fetch_fun,FetchFun}</code></dt>
 %%      <dd>Call back function to fetch an external resource.</dd>
@@ -51,8 +51,7 @@
 -module(xmerl_xsd).
 
 %%----------------------------------------------------------------------
-%% Include files
-%%----------------------------------------------------------------------
+%% Include files%%----------------------------------------------------------------------
 -include("xmerl.hrl").
 -include("xmerl_internal.hrl").
 -include("xmerl_xsd.hrl").
@@ -64,13 +63,17 @@
 -type global_state() :: #xsd_state{}.
 %% The global state of the validator.
 
--type fetch_fun() :: fun((Schema::file:name(), Options::option_list()) ->
-                                {ok,term(),term()} | {error,term()}).
+-type fetch_fun() :: fun((Schema::file:name(), Options::option_list())
+                         -> {ok,term(),term()} | {error,term()}).
 -type option_list() :: {tab2file, boolean()} |
                        {xsdbase, file:name()} |
                        {fetch_fun, fetch_fun()} |
                        {fetch_path, [file:name()]} |
                        {state, global_state()}.
+
+-type error_tuple() :: {atom(), term()} |
+                       {atom(), term(), term()} |
+                       {atom(), term(), term(), term()}.
 
 %%----------------------------------------------------------------------
 %% External exports
@@ -103,18 +106,15 @@
 %% Functions
 %%======================================================================
 
-%% @spec validate(Element,State) -> Result
-%% @equiv validate(Element,State,[])
+%% @equiv validate(Element, State, [])
+-spec validate(Element, State) -> {ValidElement,global_state()} | {error,Reasons} when
+      Element :: #xmlElement{},
+      State :: global_state(),
+      ValidElement :: #xmlElement{},
+      Reasons :: error_tuple() | [error_tuple()].
 validate(Xml,State) ->
     validate(Xml,State,[]).
 
-%% @spec validate(Element,State,Options) -> Result
-%%       Element      = XmlElement
-%%       Options      = option_list() 
-%%       Result       = {ValidElement,global_state()} | {error,Reasons}
-%%       ValidElement = XmlElement
-%%       State        = global_state()
-%%       Reasons      = [ErrorReason] | ErrorReason
 %% @doc Validates a parsed well-formed XML element (Element).
 %% <p>A call to validate/2 or validate/3 must provide a well formed 
 %% parsed XML element <code>#xmlElement{}</code> and a State,
@@ -136,26 +136,35 @@ validate(Xml,State) ->
 %% </p>
 %% <p> Observe that E2 may differ from E if for instance there are default
 %% values defined in <code>my_XML_Schema.xsd</code>.</p>
+-spec validate(Element, State, Options) -> {ValidElement,global_state()} | {error,Reasons} when
+      Element :: #xmlElement{},
+      State :: global_state(),
+      Options :: option_list(),
+      ValidElement :: #xmlElement{},
+      Reasons :: error_tuple() | [error_tuple()].
 validate(Xml,State,Opts) when is_record(State,xsd_state) ->
     S2 = initiate_state2(State,Opts),
     S3 = validation_options(S2,Opts),
     validate3(S3#xsd_state.schema_name,Xml,S3).
 
-%% @spec state2file(State) -> ok | {error,Reason}
 %% @doc Same as state2file(State,SchemaName)
 %%
 %% The name of the saved file is the same as the name of the
 %% schema, but with <code>.xss</code> extension.
+-spec state2file(State) -> ok | {error,Reason} when
+      State :: global_state(),
+      Reason :: term().
 state2file(S=#xsd_state{schema_name=SN}) ->
     state2file(S,filename:rootname(SN)).
 
-%% @spec state2file(State,FileName) -> ok | {error,Reason}
-%%       State = global_state()
-%%       FileName = filename()
 %% @doc Saves the schema state with all information of the processed
 %% schema in a file. You can provide the file name for the saved
 %% state. FileName is saved with the <code>.xss</code> extension
 %% added.
+-spec state2file(State, FileName) -> ok | {error,Reason} when
+      State :: global_state(),
+      FileName :: file:name(),
+      Reason :: term().
 state2file(S,FileName) when is_record(S,xsd_state) ->
     save_xsd_state(S),
     case catch ets:tab2file(S#xsd_state.table,lists:append(FileName,".xss")) of
@@ -164,13 +173,14 @@ state2file(S,FileName) when is_record(S,xsd_state) ->
 	Ret -> Ret
     end.
 
-%% @spec file2state(FileName) -> {ok,State} | {error,Reason}
-%%       State = global_state()
-%%       FileName = filename()
 %% @doc Reads the schema state with all information of the processed
 %% schema from a file created with <code>state2file/[1,2]</code>.  The
 %% format of this file is internal. The state can then be used
 %% validating an XML document.
+-spec file2state(FileName) -> {ok,State} | {error,Reason} when
+      FileName :: file:name(),
+      State :: global_state(),
+      Reason :: term().
 file2state(FileName) ->
     case catch ets:file2tab(FileName) of
 	{ok,Tab} ->
@@ -210,16 +220,15 @@ xmerl_xsd_vsn_check(S=#xsd_state{vsn=MD5_VSN}) ->
     
 	
 
-%% @spec process_validate(Schema,Element) -> Result
-%% @equiv process_validate(Schema,Xml,[])
+%% @equiv process_validate(Schema, Xml, [])
+-spec process_validate(Schema, Element) -> {ValidElement,global_state()} | {error,Reasons} when
+      Schema :: file:name(),
+      Element :: #xmlElement{},
+      ValidElement :: #xmlElement{},
+      Reasons :: error_tuple() | [error_tuple()].
 process_validate(Schema,Xml) ->
     process_validate(Schema,Xml,[]).
-%% @spec process_validate(Schema,Element,Options) -> Result
-%%       Schema   = filename()
-%%       Element  = XmlElement
-%%       Options  = option_list()
-%%       Result   = {ValidXmlElement,State} | {error,Reason}
-%%       Reason   = [ErrorReason] | ErrorReason
+
 %% @doc Validates a parsed well-formed XML element towards an XML
 %% schema.  <p> Validates in two steps. First it processes the schema,
 %% saves the type and structure info in an ets table and then
@@ -231,6 +240,12 @@ process_validate(Schema,Xml) ->
 %% </p>
 %% <p> Observe that E2 may differ from E if for instance there are default
 %% values defined in <code>my_XML_Schema.xsd</code>.</p>
+-spec process_validate(Schema, Element, Options) -> {ValidElement,global_state()} | {error,Reasons} when
+      Schema :: file:name(),
+      Element :: #xmlElement{},
+      Options :: option_list(),
+      ValidElement :: #xmlElement{},
+      Reasons :: error_tuple() | [error_tuple()].
 process_validate(Schema,Xml,Opts) ->
     TargetNamespace = target_namespace(Xml),
     case Schema of
@@ -290,20 +305,21 @@ validate3(Schema, Xml,S =#xsd_state{errors=[]}) ->
 validate3(_,_,S) ->
     return_schema_error(S#xsd_state.errors).
 
-%% @spec process_schema(Schema) -> Result
-%% @equiv process_schema(Schema,[])
+%% @equiv process_schema(Schema, [])
+-spec process_schema(Schema) -> {ok,global_state()} | {error,Reasons} when
+      Schema :: file:name(),
+      Reasons :: error_tuple() | [error_tuple()].
 process_schema(Schema) ->
     process_schema(Schema,[]).
-%% @spec process_schema(Schema,Options) -> Result
-%%       Schema  = filename()
-%%       Result  = {ok,State} | {error,Reason}
-%%       State   = global_state()
-%%       Reason  = [ErrorReason] | ErrorReason
-%%       Options = option_list()
+
 %% @doc Reads the referenced XML schema and checks that it is valid.
-%% Returns the <code>global_state()</code> with schema info or an 
+%% Returns the <code>global_state()</code> with schema info or an
 %% error reason. The error reason may be a list of several errors
 %% or a single error encountered during the processing.
+-spec process_schema(Schema, Options) -> {ok,global_state()} | {error,Reasons} when
+      Schema :: file:name(),
+      Options :: option_list(),
+      Reasons :: error_tuple() | [error_tuple()].
 process_schema(Schema,Options) when is_list(Options) ->
     State = initiate_state(Options,Schema),
     process_schema(Schema, State);
@@ -332,19 +348,23 @@ process_schema2({SE,_},State,_Schema) ->
 	    return_error(S3#xsd_state.errors)
     end.
 
-%% @spec process_schemas(Schemas) -> Result
-%% @equiv process_schema(Schemas,[])
+%% @equiv process_schema(Schemas, [])
+-spec process_schemas(Schemas) -> {ok,global_state()} | {error,Reasons} when
+      Schemas :: [{_NameSpace,file:name()}],
+      _NameSpace :: any(),
+      Reasons :: error_tuple() | [error_tuple()].
 process_schemas(Schemas) ->
     process_schemas(Schemas,[]).
-%% @spec process_schemas(Schemas,Options) -> Result
-%%       Schemas  = [{NameSpace,filename()}|Schemas] | []
-%%       Result   = {ok,State} | {error,Reason}
-%%       Reason   = [ErrorReason] | ErrorReason
-%%       Options  = option_list()
+
 %% @doc Reads the referenced XML schemas and controls they are valid.
-%% Returns the <code>global_state()</code> with schema info or an 
+%% Returns the <code>global_state()</code> with schema info or an
 %% error reason. The error reason may be a list of several errors
 %% or a single error encountered during the processing.
+-spec process_schemas(Schemas, Options) -> {ok,global_state()} | {error,Reasons} when
+      Schemas :: [{_NameSpace,file:name()}],
+      _NameSpace :: any(),
+      Options :: option_list(),
+      Reasons :: error_tuple() | [error_tuple()].
 process_schemas(Schemas=[{_,Schema}|_],Options) when is_list(Options) ->
     State = initiate_state(Options,Schema),
     process_schemas(Schemas, State);
@@ -5439,11 +5459,11 @@ add_key_once(Key,N,El,L) ->
 %% %%    ?dbg("mk_xml_path: Parents = ~p~n",[Parents]),
 %%     {filename:join([[io_lib:format("/~w(~w)",[X,Y])||{X,Y}<-Parents],Type]),Pos}.
 
-%% @spec format_error(Errors) -> Result
-%%       Errors     = error_tuple() | [error_tuple()]
-%%       Result       = string() | [string()]
 %% @doc Formats error descriptions to human readable strings.
-format_error(L) when is_list(L) -> 
+-spec format_error(Errors) -> Result when
+      Errors :: error_tuple() | [error_tuple()],
+      Result :: string() | [string()].
+format_error(L) when is_list(L) ->
     [format_error(X)||X<-L];
 format_error({unexpected_rest,UR}) ->
     io_lib:format("XML: The following content of an element didn't validate by the provided schema, ~n~p.",[UR]);

--- a/lib/xmerl/src/xmerl_xsd.erl
+++ b/lib/xmerl/src/xmerl_xsd.erl
@@ -24,9 +24,6 @@
 %% of XML Schema second edition 28 october 2004. For an introduction to
 %% XML Schema study <a href="http://www.w3.org/TR/xmlschema-0/">part 0.</a>
 %% An XML structure is validated by xmerl_xsd:validate/[2,3].
-%% @type global_state(). <p>The global state of the validator. It is 
-%% representated by the <code>#xsd_state{}</code> record.
-%% </p>
 %% @type option_list(). <p>Options allow to customize the behaviour of the 
 %% validation.
 %% </p>
@@ -60,6 +57,20 @@
 -include("xmerl_internal.hrl").
 -include("xmerl_xsd.hrl").
 -include_lib("kernel/include/file.hrl").
+
+%%----------------------------------------------------------------------
+%% Internal types
+%%----------------------------------------------------------------------
+-type global_state() :: #xsd_state{}.
+%% The global state of the validator.
+
+-type fetch_fun() :: fun((Schema::file:name(), Options::option_list()) ->
+                                {ok,term(),term()} | {error,term()}).
+-type option_list() :: {tab2file, boolean()} |
+                       {xsdbase, file:name()} |
+                       {fetch_fun, fetch_fun()} |
+                       {fetch_path, [file:name()]} |
+                       {state, global_state()}.
 
 %%----------------------------------------------------------------------
 %% External exports


### PR DESCRIPTION
Followup of #935 (rebased from `maint` to `master` and GitHub disallows changing the base branch).
- rebased on top of master
- added specs to `@equiv` that missed them
- edited specs thus removing `@spec`
- issues:
  1. https://github.com/erlang/otp/pull/935#discussion_r56747242
  2. https://github.com/erlang/otp/pull/935#discussion_r56747305
- Does the move away from `edoc` for `common_test` mean that specs will be duplicated in the XML & ERL files?
- Did I get something wrong?
  - `xmerl_sax_parser_latin1.erl:203: Warning: this clause cannot match because 'undefined' is not of the expected type 'integer'`
  - `xmerl_sax_parser_latin1.erl:1776: Warning: this clause cannot match because 'undefined' is not of the expected type 'integer'`
- Had to specify `edoc_module() :: #xmlElement{}` (compiler complained it was under specified thus useless)
  - so I included xmerl.hrl in edoc.erl
